### PR TITLE
vm-allocator design implementation

### DIFF
--- a/vm-allocator/Cargo.toml
+++ b/vm-allocator/Cargo.toml
@@ -1,0 +1,9 @@
+[package]
+name = "vm-allocator"
+version = "0.1.0"
+authors = ["The Chromium OS Authors"]
+edition = "2018"
+
+[dependencies]
+libc = ">=0.2.39"
+vm-memory = { git = "https://github.com/rust-vmm/vm-memory" }

--- a/vm-allocator/README.md
+++ b/vm-allocator/README.md
@@ -1,0 +1,136 @@
+#vm-allocator
+
+The `vm-allocator` crate is the rust-vmm resource allocator and manager. It provides
+high level APIs for each kind of resources that would be used by VMMs. Meanwhile,
+it provides a system level allocator that manages all resources instances for VMMs.
+
+## Objectives
+
+A Virtual Machine Manager (VMM) needs to manager the system resources like port IO
+address space resource, memory-mapped I/O space resource, etc. And it also needs
+to have a mechnism allocating such resources for devices in case of no firmware case.
+
+## Architecture
+
+### `Resource` and `ResourceSize` traits 
+
+The `Resource` and `ResourceSize` traits are designed for each resource type like
+port I/O address space resource, memory-mapped I/O space resource, legacy IRQ, etc,
+which should implement the traits for allocation usage.
+
+### `ResourceAllocator` trait
+
+This is an abstration of each resource allocator mechanism, having `fn allocate()`
+and `fn free()` methods with parameters implementing `Resource` and `ResourceSize`
+traits describing the allocation and free requests.
+
+### `IdAllocator`
+
+This is an allocator structure implementing `ResourceAllocator` trait, and responsible
+for any unsigned integer 32-bit resource type. For VMMs, legacy IRQ and device instance
+id might be such resource.
+
+### `AddressAllocator`
+
+This is an allocator structure implementing `ResourceAllocator` trait, and responsible
+for allocating and freeing a range of guest addresses. For VMMs, port I/O address space
+resource, memory-mapped I/O space resource would be such resource.
+
+### `SystemAllocator` trait
+
+This trait is a system level allocator management for some VMMs, and can provides resource
+allocation callbacks to dynamically allocate or free some resources on demand. This
+helps caller decouple with VMM's system allocator.
+
+Every VMMs can choose to implement this trait or not, according to whether the VMM wants to
+have a lightweight allocation mechanism and resources lifetime management e.g. serverless.
+
+A `Option<>` of callback could be a good way to make things alternatively. If a VMM wants
+itself responsible for resource allocation, it can simply register a None callback inside
+`vm-device` crate. If a VMM wants `vm-device` crate do the resources allocation management,
+it can simply register the callback inside `vm-device` crate.
+
+## Example
+
+Before giving out different use cases, let's see the DeviceManager members.
+
+```Rust
+pub struct DeviceManager {
+    device_id_cb: Option<IdAllocateFunc>,
+    /// IRQ allocator callback.
+    irq_cb: Option<IdAllocateFunc>,
+    /// Port IO address resource allocator callback.
+    pio_addr_cb: Option<AddrAllocateFunc>,
+    /// Mmio address resource allocator callback.
+    mmio_addr_cb: Option<AddrAllocateFunc>,
+
+    /// Range mapping for VM exit mmio operations.
+    mmio_bus: BTreeMap<Range, Arc<dyn Device>>,
+    /// Range mapping for VM exit pio operations.
+    pio_bus: BTreeMap<Range, Arc<dyn Device>>,
+}
+
+```
+Case 1:
+Let's create a lightweight VMM and make it allocate resources byself.
+
+```Rust
+// First we have a very simple system allocator.
+struct SystemAllocator {
+    irq: IdAllocator,
+    device_id: IdAllocator,
+}
+
+let sys_alloc = SystemAllocator::new();
+
+// VMM has a dummy-device-1 instance.
+let dummy = DummyDevice::new();
+
+// VMM wants to allocate each device resources by self.
+let instance_id = sys_alloc.allocate_instance_id();
+let irq = sys_alloc.allocate_irq();
+
+// Register dummy-device-1 into vm-device::DeviceManager
+// by a simple API with a known resources.
+let dev_mgr = DeviceManager::new();
+dev_mgr.simple_register_device(dummy, instance_id, irq, (0xcf8, 8));
+
+// No unhotplug or unregister use case so no need to free.
+```
+
+Case 2:
+Let's create a normal VMM which would be used with no firmware. 
+
+```Rust
+// First we have a system allocator which needs thread safe.
+struct SystemAllocator {
+    pio_addr: Arc<Mutex<AddrAllocator>>,
+    mmio_addr: Arc<Mutex<AddrAllocator>>,
+    irq: Arc<Mutex<IdAllocator>>,
+    device_id: Arc<Mutex<IdAllocator>>,
+}
+
+let sys_alloc = SystemAllocator::new();
+
+// VMM has a dummy-device-1 instance.
+// And it gives out a vector which resources are needed like port IO address, irq.
+let dummy = DummyDevice::new();
+let resource:Vec<> = dummy.resource_request();
+
+// The VMM wants to register the device.
+// full_register_device() would call the allocation callback to allocate
+// irq, instance id, port IO resources and then do simple_register_device().
+// In such case, each callback would be Some(cb).
+let dev_mgr = DeviceManager::new();
+let instance_id = dev_mgr.full_register_device(dummy, resource);
+
+// When dummy is unhotplugged, VMM calls device manager to free resources and unregister.
+dev_mgr.full_unregister_device(instance_id);
+```
+
+Case 3:
+A VMM with firmware allocation resources.
+
+Parts of device resources need to be allocated by VMMs, and parts are allocated by firmware.
+So `Option<>` type for callbacks are useful in such case. In such case, some callbacks would
+be `Some(cb)` like port IO, and some would be `None` like mmio.

--- a/vm-allocator/src/address.rs
+++ b/vm-allocator/src/address.rs
@@ -1,0 +1,365 @@
+// Copyright 2018 The Chromium OS Authors. All rights reserved.
+// Copyright © 2019 Intel Corporation
+//
+// Portions Copyright 2017 The Chromium OS Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE-BSD-3-Clause file.
+//
+// SPDX-License-Identifier: Apache-2.0 OR BSD-3-Clause
+
+use std::collections::btree_map::BTreeMap;
+use std::result;
+use vm_memory::{Address, GuestAddress, GuestUsize};
+
+use crate::resource::{Error, Resource, ResourceAllocator, ResourceSize};
+
+pub type Result<T> = result::Result<T, Error>;
+
+impl Resource for GuestAddress {}
+impl ResourceSize for u64 {}
+
+/// Manages allocating address ranges.
+/// Use `AddressAllocator` whenever an address range needs to be allocated to different users.
+///
+/// # Examples
+///
+/// ```
+/// use vm_allocator::AddressAllocator;
+/// use vm_allocator::ResourceAllocator;
+/// use vm_memory::{Address, GuestAddress, GuestUsize};
+///
+///   AddressAllocator::new(GuestAddress(0x1000), 0x10000, Some(0x100)).map(|mut pool| {
+///       assert_eq!(pool.allocate(None, 0x110).unwrap(), GuestAddress(0x10e00));
+///       assert_eq!(pool.allocate(None, 0x100).unwrap(), GuestAddress(0x10d00));
+///   });
+/// ```
+#[derive(Debug, Eq, PartialEq)]
+pub struct AddressAllocator {
+    base: GuestAddress,
+    end: GuestAddress,
+    alignment: GuestUsize,
+    ranges: BTreeMap<GuestAddress, GuestUsize>,
+}
+
+impl AddressAllocator {
+    /// Creates a new `AddressAllocator` for managing a range of addresses.
+    /// Can return `None` if `base` + `size` overflows a u64 or if alignment isn't a power
+    /// of two.
+    ///
+    /// * `base` - The starting address of the range to manage.
+    /// * `size` - The size of the address range in bytes.
+    /// * `align_size` - The minimum size of an address region to align to, defaults to four.
+    pub fn new(
+        base: GuestAddress,
+        size: GuestUsize,
+        align_size: Option<GuestUsize>,
+    ) -> Option<Self> {
+        if size == 0 {
+            return None;
+        }
+        let bound = base.checked_add(size)?;
+        let alignment = align_size.unwrap_or(4);
+        if !alignment.is_power_of_two() || alignment == 0 {
+            return None;
+        }
+
+        let end = bound.unchecked_sub(1);
+        let mut allocator = AddressAllocator {
+            base,
+            end,
+            alignment,
+            ranges: BTreeMap::new(),
+        };
+
+        // Insert the last address as a zero size range.
+        // This is our end of address space marker.
+        allocator.ranges.insert(bound, 0);
+
+        Some(allocator)
+    }
+
+    fn align_address(&self, address: GuestAddress) -> Option<GuestAddress> {
+        let align_adjust = if address.raw_value() % self.alignment != 0 {
+            self.alignment - (address.raw_value() % self.alignment)
+        } else {
+            0
+        };
+
+        address.checked_add(align_adjust)
+    }
+
+    fn available_range(
+        &self,
+        req_address: GuestAddress,
+        req_size: GuestUsize,
+    ) -> Result<GuestAddress> {
+        let aligned_address = self.align_address(req_address).ok_or(Error::Overflow)?;
+
+        // The requested address should be aligned.
+        if aligned_address != req_address {
+            return Err(Error::UnalignedAddress);
+        }
+
+        // The aligned address should be within the address space range.
+        if aligned_address > self.end || aligned_address < self.base {
+            return Err(Error::Overflow);
+        }
+
+        let mut prev_end_address = self.base;
+        for (address, size) in self.ranges.iter() {
+            if aligned_address <= *address {
+                // Do we overlap with the previous range?
+                if prev_end_address > aligned_address {
+                    return Err(Error::Overlap);
+                }
+
+                // Do we have enough space?
+                if address
+                    .unchecked_sub(aligned_address.raw_value())
+                    .raw_value()
+                    < req_size
+                {
+                    return Err(Error::Overlap);
+                }
+
+                return Ok(aligned_address);
+            }
+
+            prev_end_address = address.unchecked_add(*size);
+        }
+
+        // We have not found a range that starts after the requested address,
+        // despite having a marker at the end of our range.
+        Err(Error::Overflow)
+    }
+
+    fn first_available_range(&self, req_size: GuestUsize) -> Result<GuestAddress> {
+        let mut prev_end_address = self.base;
+
+        for (address, size) in self.ranges.iter() {
+            // If we have enough space between this range and the previous one,
+            // we return the start of this range minus the requested size.
+            // As each new range is allocated at the end of the available address space,
+            // we will tend to always allocate new ranges there as well. In other words,
+            // ranges accumulate at the end of the address space.
+            let prev_end_align = self
+                .align_address(prev_end_address)
+                .ok_or(Error::Overflow)?;
+
+            if address
+                .unchecked_sub(prev_end_align.raw_value())
+                .raw_value()
+                >= req_size
+            {
+                let req_align = self
+                    .align_address(GuestAddress(req_size))
+                    .ok_or(Error::Overflow)?;
+                let addr = self
+                    .align_address(address.unchecked_sub(req_align.raw_value()))
+                    .ok_or(Error::Overflow)?;
+
+                return Ok(addr);
+            }
+
+            prev_end_address = address.unchecked_add(*size);
+        }
+
+        Err(Error::Overflow)
+    }
+}
+
+impl ResourceAllocator<GuestAddress, GuestUsize> for AddressAllocator {
+    /// Allocates a range of addresses from the managed region.
+    fn allocate(
+        &mut self,
+        address: Option<GuestAddress>,
+        size: GuestUsize,
+    ) -> Result<GuestAddress> {
+        if size == 0 {
+            return Err(Error::SizeInvalid);
+        }
+
+        let new_addr = match address {
+            Some(req_address) => self.available_range(req_address, size)?,
+            None => self.first_available_range(size)?,
+        };
+
+        self.ranges.insert(new_addr, size);
+
+        Ok(new_addr)
+    }
+
+    /// Free an already allocated address range.
+    /// We can only free a range if it matches exactly an already allocated range.
+    fn free(&mut self, address: GuestAddress, size: GuestUsize) {
+        // The last marker can not be removed.
+        if address == self.end || size == 0 {
+            return;
+        }
+        if let Some(&range_size) = self.ranges.get(&address) {
+            if size == range_size {
+                self.ranges.remove(&address);
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn new_fails_overflow() {
+        assert_eq!(
+            AddressAllocator::new(GuestAddress(u64::max_value()), 0x100, None),
+            None
+        );
+    }
+
+    #[test]
+    fn new_fails_size_zero() {
+        assert_eq!(AddressAllocator::new(GuestAddress(0x1000), 0, None), None);
+    }
+
+    #[test]
+    fn new_fails_alignment_zero() {
+        assert_eq!(
+            AddressAllocator::new(GuestAddress(0x1000), 0x10000, Some(0)),
+            None
+        );
+    }
+
+    #[test]
+    fn new_fails_alignment_non_power_of_two() {
+        assert_eq!(
+            AddressAllocator::new(GuestAddress(0x1000), 0x10000, Some(200)),
+            None
+        );
+    }
+
+    #[test]
+    fn allocate_fails_not_enough_space() {
+        let mut pool = AddressAllocator::new(GuestAddress(0x1000), 0x1000, Some(0x100)).unwrap();
+        assert_eq!(pool.allocate(None, 0x800).unwrap(), GuestAddress(0x1800));
+        assert!(pool.allocate(None, 0x900).is_err());
+        assert_eq!(pool.allocate(None, 0x400).unwrap(), GuestAddress(0x1400));
+    }
+
+    #[test]
+    fn allocate_alignment() {
+        let mut pool = AddressAllocator::new(GuestAddress(0x1000), 0x10000, Some(0x100)).unwrap();
+        assert_eq!(pool.allocate(None, 0x110).unwrap(), GuestAddress(0x10e00));
+        assert_eq!(pool.allocate(None, 0x100).unwrap(), GuestAddress(0x10d00));
+        assert_eq!(pool.allocate(None, 0x10).unwrap(), GuestAddress(0x10c00));
+    }
+
+    #[test]
+    fn allocate_address() {
+        let mut pool = AddressAllocator::new(GuestAddress(0x1000), 0x1000, None).unwrap();
+        assert_eq!(
+            pool.allocate(Some(GuestAddress(0x1200)), 0x800).unwrap(),
+            GuestAddress(0x1200)
+        );
+
+        assert_eq!(
+            pool.allocate(Some(GuestAddress(0x1a00)), 0x100).unwrap(),
+            GuestAddress(0x1a00)
+        );
+    }
+
+    #[test]
+    fn allocate_address_alignment() {
+        let mut pool = AddressAllocator::new(GuestAddress(0x1000), 0x1000, Some(0x100)).unwrap();
+        assert_eq!(
+            pool.allocate(Some(GuestAddress(0x1200)), 0x800).unwrap(),
+            GuestAddress(0x1200)
+        );
+
+        // Unaligned request
+        assert!(pool.allocate(Some(GuestAddress(0x1210)), 0x800).is_err());
+
+        // Aligned request
+        assert_eq!(
+            pool.allocate(Some(GuestAddress(0x1b00)), 0x100).unwrap(),
+            GuestAddress(0x1b00)
+        );
+    }
+
+    #[test]
+    fn allocate_address_not_enough_space() {
+        let mut pool = AddressAllocator::new(GuestAddress(0x1000), 0x1000, Some(0x100)).unwrap();
+
+        // First range is [0x1200:0x1a00]
+        assert_eq!(
+            pool.allocate(Some(GuestAddress(0x1200)), 0x800).unwrap(),
+            GuestAddress(0x1200)
+        );
+
+        // Second range is [0x1c00:0x1e00]
+        assert_eq!(
+            pool.allocate(Some(GuestAddress(0x1c00)), 0x200).unwrap(),
+            GuestAddress(0x1c00)
+        );
+
+        // There is 0x200 between the first 2 ranges.
+        // We ask for an available address but the range is too big
+        assert!(pool.allocate(Some(GuestAddress(0x1b00)), 0x800).is_err());
+
+        // We ask for an available address, with a small enough range
+        assert_eq!(
+            pool.allocate(Some(GuestAddress(0x1b00)), 0x100).unwrap(),
+            GuestAddress(0x1b00)
+        );
+    }
+
+    #[test]
+    fn allocate_address_free_and_realloc() {
+        let mut pool = AddressAllocator::new(GuestAddress(0x1000), 0x1000, Some(0x100)).unwrap();
+
+        // First range is [0x1200:0x1a00]
+        assert_eq!(
+            pool.allocate(Some(GuestAddress(0x1200)), 0x800).unwrap(),
+            GuestAddress(0x1200)
+        );
+
+        pool.free(GuestAddress(0x1200), 0x800);
+
+        assert_eq!(
+            pool.allocate(Some(GuestAddress(0x1200)), 0x800).unwrap(),
+            GuestAddress(0x1200)
+        );
+    }
+
+    #[test]
+    fn allocate_address_free_fail_and_realloc() {
+        let mut pool = AddressAllocator::new(GuestAddress(0x1000), 0x1000, Some(0x100)).unwrap();
+
+        // First range is [0x1200:0x1a00]
+        assert_eq!(
+            pool.allocate(Some(GuestAddress(0x1200)), 0x800).unwrap(),
+            GuestAddress(0x1200)
+        );
+
+        // We try to free a range smaller than the allocated one.
+        pool.free(GuestAddress(0x1200), 0x100);
+
+        assert!(pool.allocate(Some(GuestAddress(0x1200)), 0x800).is_err());
+    }
+
+    #[test]
+    fn allocate_address_fail_free_and_realloc() {
+        let mut pool = AddressAllocator::new(GuestAddress(0x1000), 0x1000, Some(0x100)).unwrap();
+
+        // First allocation fails
+        assert!(pool.allocate(Some(GuestAddress(0x1200)), 0x2000).is_err());
+
+        // We try to free a range that was not allocated.
+        pool.free(GuestAddress(0x1200), 0x2000);
+
+        // Now we try an allocation that should succeed.
+        assert_eq!(
+            pool.allocate(Some(GuestAddress(0x1200)), 0x800).unwrap(),
+            GuestAddress(0x1200)
+        );
+    }
+}

--- a/vm-allocator/src/id.rs
+++ b/vm-allocator/src/id.rs
@@ -1,0 +1,119 @@
+// Copyright 2018 The Chromium OS Authors. All rights reserved.
+// Copyright © 2019 Intel Corporation
+//
+// Portions Copyright 2017 The Chromium OS Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE-BSD-3-Clause file.
+//
+// SPDX-License-Identifier: Apache-2.0 OR BSD-3-Clause
+
+use std::result;
+
+use crate::resource::{Error, Resource, ResourceAllocator, ResourceSize};
+
+pub type Result<T> = result::Result<T, Error>;
+
+impl Resource for u32 {}
+impl ResourceSize for u32 {}
+
+/// Manages allocating unsigned integer resources.
+/// Use `IdAllocator` whenever a unique unsigned 32-bit number needs to be allocated.
+///
+/// # Arguments
+///
+/// * `start` - The starting integer to manage.
+/// * `end` - The ending integer to manage.
+/// * `used` - The used integer ordered from lowest to highest.
+///
+/// # Examples
+///
+/// ```
+/// use vm_allocator::IdAllocator;
+/// use vm_allocator::ResourceAllocator;
+///
+/// IdAllocator::new(1, std::u32::MAX).map(|mut p| {
+///     assert_eq!(p.allocate(Some(1), 1).unwrap(), 1);
+///     assert_eq!(p.allocate(Some(3), 1).unwrap(), 3);
+/// });
+///
+/// ```
+#[derive(Debug)]
+pub struct IdAllocator {
+    start: u32,
+    end: u32,
+    used: Vec<u32>,
+}
+
+impl IdAllocator {
+    /// Creates a new `IdAllocator` for managing a range of unsigned integer.
+    pub fn new(start: u32, end: u32) -> Option<Self> {
+        Some(IdAllocator {
+            start,
+            end,
+            used: Vec::new(),
+        })
+    }
+
+    fn first_usable_number(&self) -> Result<u32> {
+        if self.used.is_empty() {
+            return Ok(self.start);
+        }
+
+        let mut previous = self.start;
+
+        for iter in self.used.iter() {
+            if *iter > previous {
+                return Ok(previous);
+            } else {
+                match iter.checked_add(1) {
+                    Some(p) => previous = p,
+                    None => return Err(Error::Overflow),
+                }
+            }
+        }
+        if previous <= self.end {
+            Ok(previous)
+        } else {
+            Err(Error::Overflow)
+        }
+    }
+}
+
+impl ResourceAllocator<u32, u32> for IdAllocator {
+    fn allocate(&mut self, resource: Option<u32>, size: u32) -> Result<u32> {
+        // `size` should be 1 because id resource allocation request can be
+        // non continuous or continuous.
+        if size != 1 || size == 0 {
+            return Err(Error::SizeInvalid);
+        }
+        let ret = match resource {
+            // Specified id resource to be allocated.
+            Some(res) => {
+                if res < self.start || res > self.end {
+                    return Err(Error::OutofScope);
+                }
+                match self.used.iter().find(|&&x| x == res) {
+                    Some(_) => {
+                        return Err(Error::Duplicated);
+                    }
+                    None => res,
+                }
+            }
+            None => self.first_usable_number()?,
+        };
+        self.used.push(ret);
+        self.used.sort();
+        Ok(ret)
+    }
+
+    /// Free an already allocated id and will keep the order.
+    fn free(&mut self, res: u32, size: u32) {
+        // Only support free a singal resource.
+        if size != 1 || size == 0 {
+            return;
+        }
+        if let Ok(idx) = self.used.binary_search(&res) {
+            self.used.remove(idx);
+        }
+    }
+}

--- a/vm-allocator/src/lib.rs
+++ b/vm-allocator/src/lib.rs
@@ -1,0 +1,20 @@
+// Copyright 2018 The Chromium OS Authors. All rights reserved.
+// Copyright © 2019 Intel Corporation
+//
+// Portions Copyright 2017 The Chromium OS Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE-BSD-3-Clause file.
+//
+// SPDX-License-Identifier: Apache-2.0 OR BSD-3-Clause
+//#![deny(missing_docs)]
+
+//! Manages system resources that can be allocated to VMs and their devices.
+#![deny(missing_docs)]
+
+extern crate libc;
+
+mod resource;
+
+pub use crate::resource::{
+    Error as ResourceAllocatorError, Resource, ResourceAllocator, ResourceSize,
+};

--- a/vm-allocator/src/lib.rs
+++ b/vm-allocator/src/lib.rs
@@ -16,9 +16,12 @@ extern crate libc;
 mod address;
 mod id;
 mod resource;
+mod system;
 
 pub use crate::address::AddressAllocator;
 pub use crate::id::IdAllocator;
 pub use crate::resource::{
     Error as ResourceAllocatorError, Resource, ResourceAllocator, ResourceSize,
 };
+pub use crate::system::SystemAllocator;
+pub use crate::system::{Error, IdAllocateFunc, IdAllocateParameters};

--- a/vm-allocator/src/lib.rs
+++ b/vm-allocator/src/lib.rs
@@ -23,5 +23,5 @@ pub use crate::id::IdAllocator;
 pub use crate::resource::{
     Error as ResourceAllocatorError, Resource, ResourceAllocator, ResourceSize,
 };
-pub use crate::system::SystemAllocator;
+pub use crate::system::{DefaultSystemAllocator, SystemAllocator};
 pub use crate::system::{Error, IdAllocateFunc, IdAllocateParameters};

--- a/vm-allocator/src/lib.rs
+++ b/vm-allocator/src/lib.rs
@@ -13,8 +13,12 @@
 
 extern crate libc;
 
+mod address;
+mod id;
 mod resource;
 
+pub use crate::address::AddressAllocator;
+pub use crate::id::IdAllocator;
 pub use crate::resource::{
     Error as ResourceAllocatorError, Resource, ResourceAllocator, ResourceSize,
 };

--- a/vm-allocator/src/resource.rs
+++ b/vm-allocator/src/resource.rs
@@ -9,13 +9,20 @@
 
 use std::fmt::{self, Display};
 
+/// Define Error list for `ResourceAllocator` trait.
 #[derive(Debug)]
 pub enum Error {
+    /// The resource allocation failed because request is out os scope.
     OutofScope,
+    /// The resource allocation failed because request is overflow.
     Overflow,
+    /// The resource allocation failed because request scope is overlap.
     Overlap,
+    /// The resource allocation failed because request is duplicated.
     Duplicated,
+    /// The resource allocation failed because of unaligned address request.
     UnalignedAddress,
+    /// The resource allocation failed because request size is invalid.
     SizeInvalid,
 }
 

--- a/vm-allocator/src/resource.rs
+++ b/vm-allocator/src/resource.rs
@@ -1,0 +1,63 @@
+// Copyright 2018 The Chromium OS Authors. All rights reserved.
+// Copyright © 2019 Intel Corporation
+//
+// Portions Copyright 2017 The Chromium OS Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE-BSD-3-Clause file.
+//
+// SPDX-License-Identifier: Apache-2.0 OR BSD-3-Clause
+
+use std::fmt::{self, Display};
+
+#[derive(Debug)]
+pub enum Error {
+    OutofScope,
+    Overflow,
+    Overlap,
+    Duplicated,
+    UnalignedAddress,
+    SizeInvalid,
+}
+
+impl Display for Error {
+    // This trait requires `fmt` with this exact signature.
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        use self::Error::*;
+
+        match self {
+            OutofScope => write!(f, "Resource being allocated is out of scope"),
+            Overflow => write!(f, "Resource being allocated is overflow"),
+            Overlap => write!(f, "Resource being allocated has overlap"),
+            Duplicated => write!(f, "Resource being allocated is duplicated"),
+            UnalignedAddress => write!(f, "Resource being allocated is unaligned"),
+            SizeInvalid => write!(f, "Resource allocation request size is invalid"),
+        }
+    }
+}
+
+/// Trait for resource types.
+pub trait Resource {}
+
+/// Trait for resource size.
+pub trait ResourceSize {}
+
+/// Allocator trait with basic allocate and free functions.
+pub trait ResourceAllocator<T: Resource, S: ResourceSize> {
+    /// Allocate some resource with given `resource` and `size`.
+    ///
+    /// # Arguments
+    ///
+    /// * `resource`: resource to be allocate.
+    /// * `size`: resource size of allocation request.
+    ///
+    fn allocate(&mut self, resource: Option<T>, size: S) -> Result<T, Error>;
+
+    /// Free resource specified by given `resource` and `size`.
+    ///
+    /// # Arguments
+    ///
+    /// * `resource`: resource to be free.
+    /// * `size`: resource size of free request.
+    ///
+    fn free(&mut self, resource: T, size: S);
+}

--- a/vm-allocator/src/system.rs
+++ b/vm-allocator/src/system.rs
@@ -7,9 +7,14 @@
 //
 // SPDX-License-Identifier: Apache-2.0 OR BSD-3-Clause
 
+use crate::address::AddressAllocator;
+use crate::id::IdAllocator;
+use crate::resource::ResourceAllocator;
 use vm_memory::{GuestAddress, GuestUsize};
 
+use std::collections::HashMap;
 use std::result;
+use std::sync::{Arc, Mutex};
 
 /// Errors associated with system resources allocation.
 #[derive(Debug)]
@@ -22,6 +27,8 @@ pub enum Error {
     IdAllocateError(crate::resource::Error),
     /// Address resource allocate fails.
     AddressAllocateError(crate::resource::Error),
+    /// Port IO address allocation fails because address is not specified.
+    InvalidPortIoAddress,
 }
 
 pub type Result<T> = result::Result<T, Error>;
@@ -70,5 +77,177 @@ pub trait SystemAllocator {
     /// MmiO address resource allocator callback.
     fn mmio_addr_cb(&mut self) -> Option<AddrAllocateFunc> {
         None
+    }
+}
+
+/// A default system level resources allocator interface.
+///
+/// vm-device needs callback functions for allocating resources.
+///
+/// # Example
+///
+/// ```
+/// use vm_allocator::*;
+///
+/// let mut vmm_allocator = DefaultSystemAllocator::new();
+/// let id_cb = vmm_allocator.allocate_device_id();
+///
+/// ```
+#[derive(Default, Clone)]
+pub struct DefaultSystemAllocator {
+    /// Address resource allocators mapped by name.
+    pub addr_alloc: HashMap<String, Arc<Mutex<AddressAllocator>>>,
+    /// Unique integer resource allocators mapped by name.
+    pub id_alloc: HashMap<String, Arc<Mutex<IdAllocator>>>,
+}
+
+impl DefaultSystemAllocator {
+    /// Create an empty system allocator.
+    pub fn new() -> Self {
+        DefaultSystemAllocator {
+            addr_alloc: HashMap::new(),
+            id_alloc: HashMap::new(),
+        }
+    }
+
+    /// Insert port IO address resource allocator into `DefaultSystemAllocator`.
+    pub fn insert_pio_addr(&mut self, allocator: Arc<Mutex<AddressAllocator>>) -> Result<()> {
+        if self.addr_alloc.contains_key("pio_addr") {
+            return Err(Error::AllocatorExist);
+        }
+        self.addr_alloc.insert("pio_addr".to_string(), allocator);
+        Ok(())
+    }
+
+    /// Insert Mmio address resource allocator into `DefaultSystemAllocator`.
+    pub fn insert_mmio_addr(&mut self, allocator: Arc<Mutex<AddressAllocator>>) -> Result<()> {
+        if self.addr_alloc.contains_key("mmio_addr") {
+            return Err(Error::AllocatorExist);
+        }
+        self.addr_alloc.insert("pio_addr".to_string(), allocator);
+        Ok(())
+    }
+
+    /// Insert a device instance id allocator.
+    ///
+    /// # Arguments
+    ///
+    /// * `allocator`: instance id resource allocator.
+    pub fn insert_device_id(&mut self, allocator: Arc<Mutex<IdAllocator>>) -> Result<()> {
+        if self.id_alloc.contains_key("device_instance") {
+            return Err(Error::AllocatorExist);
+        }
+        self.id_alloc
+            .insert("device_instance".to_string(), allocator);
+        Ok(())
+    }
+
+    /// Insert a IRQ number allocator.
+    ///
+    /// # Arguments
+    ///
+    /// * `allocator`: IRQ resource allocator.
+    pub fn insert_irq(&mut self, allocator: Arc<Mutex<IdAllocator>>) -> Result<()> {
+        if self.id_alloc.contains_key("irq") {
+            return Err(Error::AllocatorExist);
+        }
+        self.id_alloc.insert("irq".to_string(), allocator);
+        Ok(())
+    }
+}
+
+impl SystemAllocator for DefaultSystemAllocator {
+    fn device_id_cb(&mut self) -> Option<IdAllocateFunc> {
+        let id_allocator = self.id_alloc.clone();
+
+        let cb =
+            Box::new(
+                move |p: IdAllocateParameters| match id_allocator.get("device_instance") {
+                    Some(allocator) => allocator
+                        .lock()
+                        .expect("failed to acquire lock")
+                        .allocate(p.resource, 1)
+                        .map_err(Error::IdAllocateError),
+                    None => Err(Error::AllocatorNotExist),
+                },
+            ) as IdAllocateFunc;
+
+        Some(cb)
+    }
+
+    fn irq_cb(&mut self) -> Option<IdAllocateFunc> {
+        let id_allocator = self.id_alloc.clone();
+
+        let cb = Box::new(
+            move |p: IdAllocateParameters| match id_allocator.get("irq") {
+                Some(allocator) => allocator
+                    .lock()
+                    .expect("failed to acquire lock")
+                    .allocate(p.resource, 1)
+                    .map_err(Error::IdAllocateError),
+                None => Err(Error::AllocatorNotExist),
+            },
+        ) as IdAllocateFunc;
+
+        Some(cb)
+    }
+
+    fn pio_addr_cb(&mut self) -> Option<AddrAllocateFunc> {
+        let addr_allocator = self.addr_alloc.clone();
+
+        let cb = Box::new(
+            move |p: AddrAllocateParameters| match addr_allocator.get("pio_addr") {
+                Some(allocator) => { match p.resource {
+                    Some(addr) =>
+                        allocator
+                        .lock()
+                        .expect("failed to acquire lock")
+                        .allocate(Some(addr), p.size)
+                        .map_err(Error::AddressAllocateError),
+                    None => Err(Error::InvalidPortIoAddress),
+                }},
+                None => Err(Error::AllocatorNotExist),
+            },
+        ) as AddrAllocateFunc;
+
+        Some(cb)
+    }
+
+    fn mmio_addr_cb(&mut self) -> Option<AddrAllocateFunc> {
+        let addr_allocator = self.addr_alloc.clone();
+
+        let cb = Box::new(
+            move |p: AddrAllocateParameters| match addr_allocator.get("mmio_addr") {
+                Some(allocator) => allocator
+                    .lock()
+                    .expect("failed to acquire lock")
+                    .allocate(p.resource, p.size)
+                    .map_err(Error::AddressAllocateError),
+                None => Err(Error::AllocatorNotExist),
+            },
+        ) as AddrAllocateFunc;
+
+        Some(cb)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::id::IdAllocator;
+    use crate::system::{DefaultSystemAllocator, Error, IdAllocateParameters, SystemAllocator};
+    use std::sync::{Arc, Mutex};
+
+    #[test]
+    fn test_allocate() -> Result<(), Error> {
+        let mut sys = DefaultSystemAllocator::new();
+        let instance_id = IdAllocator::new(1, 100).ok_or(Error::AllocatorExist)?;
+        sys.insert_device_id(Arc::new(Mutex::new(instance_id)))?;
+
+        let cb = sys.allocate_device_id().unwrap();
+        let parameter = IdAllocateParameters { resource: Some(2) };
+
+        let id = cb(parameter)?;
+        assert_eq!(id, 2);
+        Ok(())
     }
 }

--- a/vm-allocator/src/system.rs
+++ b/vm-allocator/src/system.rs
@@ -1,0 +1,74 @@
+// Copyright 2018 The Chromium OS Authors. All rights reserved.
+// Copyright © 2019 Intel Corporation
+//
+// Portions Copyright 2017 The Chromium OS Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE-BSD-3-Clause file.
+//
+// SPDX-License-Identifier: Apache-2.0 OR BSD-3-Clause
+
+use vm_memory::{GuestAddress, GuestUsize};
+
+use std::result;
+
+/// Errors associated with system resources allocation.
+#[derive(Debug)]
+pub enum Error {
+    /// The allocator already exists when adding a new one.
+    AllocatorExist,
+    /// The allocator doesn't exists when trying to allocate.
+    AllocatorNotExist,
+    /// Unsigned integer resource allocate fails.
+    IdAllocateError(crate::resource::Error),
+    /// Address resource allocate fails.
+    AddressAllocateError(crate::resource::Error),
+}
+
+pub type Result<T> = result::Result<T, Error>;
+
+/// The parameters that integer resource allocation needs.
+pub struct IdAllocateParameters {
+    /// Resource to be allocated or freed.
+    pub resource: Option<u32>,
+    /// Specify resource to be allocated or freed.
+    pub allocate: bool,
+}
+
+/// The parameters that address resource allocation needs.
+pub struct AddrAllocateParameters {
+    /// Resource to be allocated or freed.
+    pub resource: Option<GuestAddress>,
+    /// Size to be allocated or freed.
+    pub size: GuestUsize,
+    /// Specify resource to be allocated or freed.
+    pub allocate: bool,
+}
+
+/// Integer resource allocation callback type.
+pub type IdAllocateFunc = Box<Fn(IdAllocateParameters) -> Result<(u32)>>;
+
+/// Address resource allocation callback type.
+pub type AddrAllocateFunc = Box<Fn(AddrAllocateParameters) -> Result<(GuestAddress)>>;
+
+/// System level allocator trait for VMM.
+pub trait SystemAllocator {
+    /// Integer resource allocator callback.
+    fn device_id_cb(&mut self) -> Option<IdAllocateFunc> {
+        None
+    }
+
+    /// Integer resource allocator callback.
+    fn irq_cb(&mut self) -> Option<IdAllocateFunc> {
+        None
+    }
+
+    /// Port IO address resource allocator callback.
+    fn pio_addr_cb(&mut self) -> Option<AddrAllocateFunc> {
+        None
+    }
+
+    /// MmiO address resource allocator callback.
+    fn mmio_addr_cb(&mut self) -> Option<AddrAllocateFunc> {
+        None
+    }
+}


### PR DESCRIPTION
@andreeaflorescu @sameo 
As discussed in the meeting on July 15th, I prepared vm-allocator patches from scratch. For easily reviewing, I split each functional module into separate commit. Let's quickly review the vm-allocator design for now and we can split them into several PRs later if we agree with the design.

BTW, I prefer to have an explicit repo for the vm-allocator PR later. :)

For quickly getting the information discussed before, some are listed as below.
- Proposal to implement system allocator in each VMM: 
https://github.com/rust-vmm/community/issues/33#issuecomment-511375675
https://github.com/rust-vmm/community/issues/33#issuecomment-511403087
- Proposal for spliting PR: https://github.com/rust-vmm/vm-device/pull/3#issuecomment-511389328 

