### PR TITLE
Add interrupt subsystem to vm-device

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "rust-vmm-ci"]
+	path = rust-vmm-ci
+	url = https://github.com/rust-vmm/rust-vmm-ci.git

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,5 +4,6 @@ version = "0.1.0"
 authors = ["Samuel Ortiz <sameo@linux.intel.com>"]
 repository = "https://github.com/rust-vmm/vm-device"
 license = "Apache-2.0"
+edition = "2018"
 
 [dependencies]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,6 +8,9 @@ edition = "2018"
 
 [dependencies]
 libc = ">=0.2.39"
+kvm-bindings = { version = "0.1", optional = true }
+kvm-ioctls = { git = "https://github.com/rust-vmm/kvm-ioctls.git", branch = "master", optional = true }
 vmm-sys-util = { git = "https://github.com/rust-vmm/vmm-sys-util.git", branch = "master" }
 
 [features]
+kvm_irq = ["kvm-ioctls", "kvm-bindings"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,3 +14,4 @@ vmm-sys-util = { git = "https://github.com/rust-vmm/vmm-sys-util.git", branch = 
 
 [features]
 kvm_irq = ["kvm-ioctls", "kvm-bindings"]
+legacy_irq = []

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,3 +7,7 @@ license = "Apache-2.0"
 edition = "2018"
 
 [dependencies]
+libc = ">=0.2.39"
+vmm-sys-util = { git = "https://github.com/rust-vmm/vmm-sys-util.git", branch = "master" }
+
+[features]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,3 +15,5 @@ vmm-sys-util = { git = "https://github.com/rust-vmm/vmm-sys-util.git", branch = 
 [features]
 kvm_irq = ["kvm-ioctls", "kvm-bindings"]
 legacy_irq = []
+generic_msi = []
+msi_irq = ["generic_msi"]

--- a/coverage_config.json
+++ b/coverage_config.json
@@ -1,0 +1,5 @@
+{
+  "coverage_score": 60.3,
+  "exclude_path": "",
+  "crate_features": "kvm_irq,msi_irq,legacy_irq"
+}

--- a/src/interrupt/kvm_irq/generic_msi.rs
+++ b/src/interrupt/kvm_irq/generic_msi.rs
@@ -56,3 +56,66 @@ pub(super) fn create_msi_routing_entries(
     }
     Ok(entries)
 }
+
+#[cfg(test)]
+mod test {
+    use super::*;
+
+    #[test]
+    fn test_create_msiconfig() {
+        let config = MsiConfig::new();
+        config.irqfd.write(1).unwrap();
+    }
+
+    #[test]
+    fn test_new_msi_routing_single() {
+        let test_gsi = 4;
+        let msi_source_config = MsiIrqSourceConfig {
+            high_addr: 0x1234,
+            low_addr: 0x5678,
+            data: 0x9876,
+        };
+        let entry = new_msi_routing_entry(test_gsi, &msi_source_config);
+        assert_eq!(entry.gsi, test_gsi);
+        assert_eq!(entry.type_, KVM_IRQ_ROUTING_MSI);
+        unsafe {
+            assert_eq!(entry.u.msi.address_hi, msi_source_config.high_addr);
+            assert_eq!(entry.u.msi.address_lo, msi_source_config.low_addr);
+            assert_eq!(entry.u.msi.data, msi_source_config.data);
+        }
+    }
+
+    #[test]
+    fn test_new_msi_routing_multi() {
+        let mut msi_fds = Vec::with_capacity(16);
+        for _ in 0..16 {
+            msi_fds.push(InterruptSourceConfig::MsiIrq(MsiIrqSourceConfig {
+                high_addr: 0x1234,
+                low_addr: 0x5678,
+                data: 0x9876,
+            }));
+        }
+        let mut legacy_fds = Vec::with_capacity(16);
+        for _ in 0..16 {
+            legacy_fds.push(InterruptSourceConfig::LegacyIrq(LegacyIrqSourceConfig {}));
+        }
+
+        let base = 0;
+        let entrys = create_msi_routing_entries(0, &msi_fds).unwrap();
+
+        for (i, entry) in entrys.iter().enumerate() {
+            assert_eq!(entry.gsi, (base + i) as u32);
+            assert_eq!(entry.type_, KVM_IRQ_ROUTING_MSI);
+            if let InterruptSourceConfig::MsiIrq(config) = &msi_fds[i] {
+                unsafe {
+                    assert_eq!(entry.u.msi.address_hi, config.high_addr);
+                    assert_eq!(entry.u.msi.address_lo, config.low_addr);
+                    assert_eq!(entry.u.msi.data, config.data);
+                }
+            }
+        }
+
+        assert!(create_msi_routing_entries(0, &legacy_fds).is_err());
+        assert!(create_msi_routing_entries(!0, &msi_fds).is_err());
+    }
+}

--- a/src/interrupt/kvm_irq/generic_msi.rs
+++ b/src/interrupt/kvm_irq/generic_msi.rs
@@ -1,0 +1,58 @@
+// Copyright (C) 2019 Alibaba Cloud. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+//! Helper utilities for handling MSI interrupts.
+
+use super::*;
+use kvm_bindings::{kvm_irq_routing_entry, KVM_IRQ_ROUTING_MSI};
+
+pub(super) struct MsiConfig {
+    pub(super) irqfd: EventFd,
+    pub(super) config: Mutex<MsiIrqSourceConfig>,
+}
+
+impl MsiConfig {
+    pub(super) fn new() -> Self {
+        MsiConfig {
+            irqfd: EventFd::new(0).unwrap(),
+            config: Mutex::new(Default::default()),
+        }
+    }
+}
+
+pub(super) fn new_msi_routing_entry(
+    gsi: InterruptIndex,
+    msicfg: &MsiIrqSourceConfig,
+) -> kvm_irq_routing_entry {
+    let mut entry = kvm_irq_routing_entry {
+        gsi,
+        type_: KVM_IRQ_ROUTING_MSI,
+        flags: 0,
+        ..Default::default()
+    };
+    unsafe {
+        entry.u.msi.address_hi = msicfg.high_addr;
+        entry.u.msi.address_lo = msicfg.low_addr;
+        entry.u.msi.data = msicfg.data;
+    }
+    entry
+}
+
+pub(super) fn create_msi_routing_entries(
+    base: InterruptIndex,
+    configs: &[InterruptSourceConfig],
+) -> Result<Vec<kvm_irq_routing_entry>> {
+    let _ = base
+        .checked_add(configs.len() as u32)
+        .ok_or_else(|| std::io::Error::from_raw_os_error(libc::EINVAL))?;
+    let mut entries = Vec::with_capacity(configs.len());
+    for (i, ref val) in configs.iter().enumerate() {
+        if let InterruptSourceConfig::MsiIrq(msicfg) = val {
+            let entry = new_msi_routing_entry(base + i as u32, msicfg);
+            entries.push(entry);
+        } else {
+            return Err(std::io::Error::from_raw_os_error(libc::EINVAL));
+        }
+    }
+    Ok(entries)
+}

--- a/src/interrupt/kvm_irq/legacy_irq.rs
+++ b/src/interrupt/kvm_irq/legacy_irq.rs
@@ -10,6 +10,9 @@ use super::*;
 use std::os::unix::io::AsRawFd;
 use std::sync::atomic::{AtomicUsize, Ordering};
 
+/// Maximum number of legacy interrupts supported.
+pub const MAX_LEGACY_IRQS: u32 = 24;
+
 pub(super) struct LegacyIrq {
     base: u32,
     vmfd: Arc<VmFd>,
@@ -28,6 +31,11 @@ impl LegacyIrq {
         if count != 1 {
             return Err(std::io::Error::from_raw_os_error(libc::EINVAL));
         }
+
+        if base >= MAX_LEGACY_IRQS {
+            return Err(std::io::Error::from_raw_os_error(libc::EINVAL));
+        }
+
         Ok(Arc::new(LegacyIrq {
             base,
             vmfd,

--- a/src/interrupt/kvm_irq/legacy_irq.rs
+++ b/src/interrupt/kvm_irq/legacy_irq.rs
@@ -1,0 +1,109 @@
+// Copyright (C) 2019 Alibaba Cloud. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+//! Manage virtual device's legacy interrupts based on Linux KVM framework.
+//!
+//! On x86 platforms, legacy interrupts are those managed by the Master PIC, the slave PIC and
+//! IOAPICs.
+
+use super::*;
+use std::os::unix::io::AsRawFd;
+use std::sync::atomic::{AtomicUsize, Ordering};
+
+pub(super) struct LegacyIrq {
+    base: u32,
+    vmfd: Arc<VmFd>,
+    irqfd: EventFd,
+    status: AtomicUsize,
+}
+
+impl LegacyIrq {
+    #[allow(clippy::new_ret_no_self)]
+    pub(super) fn new(
+        base: InterruptIndex,
+        count: InterruptIndex,
+        vmfd: Arc<VmFd>,
+        _routes: Arc<KvmIrqRouting>,
+    ) -> Result<Arc<dyn InterruptSourceGroup>> {
+        if count != 1 {
+            return Err(std::io::Error::from_raw_os_error(libc::EINVAL));
+        }
+        Ok(Arc::new(LegacyIrq {
+            base,
+            vmfd,
+            irqfd: EventFd::new(0)?,
+            status: AtomicUsize::new(0),
+        }))
+    }
+}
+
+impl InterruptSourceGroup for LegacyIrq {
+    fn get_type(&self) -> InterruptSourceType {
+        InterruptSourceType::LegacyIrq
+    }
+
+    fn len(&self) -> u32 {
+        1
+    }
+
+    fn get_base(&self) -> u32 {
+        self.base
+    }
+
+    fn get_irqfd(&self, index: InterruptIndex) -> Option<&EventFd> {
+        if index != 0 {
+            None
+        } else {
+            Some(&self.irqfd)
+        }
+    }
+
+    fn enable(&self, configs: &[InterruptSourceConfig]) -> Result<()> {
+        if configs.len() != 1 {
+            return Err(std::io::Error::from_raw_os_error(libc::EINVAL));
+        }
+        // The IRQ routings for legacy IRQs have been configured during
+        // KvmIrqManager::initialize(), so only need to register irqfd to the KVM driver.
+        self.vmfd.register_irqfd(self.irqfd.as_raw_fd(), self.base)
+    }
+
+    fn disable(&self) -> Result<()> {
+        self.vmfd
+            .unregister_irqfd(self.irqfd.as_raw_fd(), self.base)
+    }
+
+    fn modify(&self, index: InterruptIndex, _config: &InterruptSourceConfig) -> Result<()> {
+        // For legacy interrupts, the routing configuration is managed by the PIC/IOAPIC interrupt
+        // controller drivers, so nothing to do here.
+        if index != 0 {
+            return Err(std::io::Error::from_raw_os_error(libc::EINVAL));
+        }
+        Ok(())
+    }
+
+    fn trigger(&self, index: InterruptIndex, flags: u32) -> Result<()> {
+        if index != 0 {
+            return Err(std::io::Error::from_raw_os_error(libc::EINVAL));
+        }
+        // Set interrupt status bits before writing to the irqfd.
+        self.status.fetch_or(flags as usize, Ordering::SeqCst);
+        self.irqfd.write(1)
+    }
+
+    fn ack(&self, index: InterruptIndex, flags: u32) -> Result<()> {
+        if index != 0 {
+            return Err(std::io::Error::from_raw_os_error(libc::EINVAL));
+        }
+        // Clear interrupt status bits.
+        self.status.fetch_and(!(flags as usize), Ordering::SeqCst);
+        Ok(())
+    }
+
+    fn get_flags(&self, index: InterruptIndex) -> u32 {
+        if index == 0 {
+            self.status.load(Ordering::SeqCst) as u32
+        } else {
+            0
+        }
+    }
+}

--- a/src/interrupt/kvm_irq/mod.rs
+++ b/src/interrupt/kvm_irq/mod.rs
@@ -264,7 +264,7 @@ impl KvmIrqRouting {
         }
 
         // Build routings for the first IOAPIC
-        for i in 0..24 {
+        for i in 0..legacy_irq::MAX_LEGACY_IRQS {
             if i == 0 {
                 Self::add_legacy_entry(i, KVM_IRQCHIP_IOAPIC, 2, routes)?;
             } else if i != 2 {

--- a/src/interrupt/kvm_irq/mod.rs
+++ b/src/interrupt/kvm_irq/mod.rs
@@ -24,6 +24,14 @@ mod legacy_irq;
 #[cfg(feature = "legacy_irq")]
 use self::legacy_irq::LegacyIrq;
 
+#[cfg(feature = "generic_msi")]
+mod generic_msi;
+
+#[cfg(feature = "msi_irq")]
+mod msi_irq;
+#[cfg(feature = "msi_irq")]
+use self::msi_irq::MsiIrq;
+
 /// Structure to manage interrupt sources for a virtual machine based on the Linux KVM framework.
 ///
 /// The KVM framework provides methods to inject interrupts into the target virtual machines,

--- a/src/interrupt/kvm_irq/mod.rs
+++ b/src/interrupt/kvm_irq/mod.rs
@@ -19,6 +19,11 @@ use kvm_ioctls::VmFd;
 
 use super::*;
 
+#[cfg(feature = "legacy_irq")]
+mod legacy_irq;
+#[cfg(feature = "legacy_irq")]
+use self::legacy_irq::LegacyIrq;
+
 /// Structure to manage interrupt sources for a virtual machine based on the Linux KVM framework.
 ///
 /// The KVM framework provides methods to inject interrupts into the target virtual machines,

--- a/src/interrupt/kvm_irq/mod.rs
+++ b/src/interrupt/kvm_irq/mod.rs
@@ -1,0 +1,260 @@
+// Copyright (C) 2019 Alibaba Cloud. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+//! Manage virtual device's interrupts based on the Linux KVM framework.
+//!
+//! When updaing KVM IRQ routing by ioctl(KVM_SET_GSI_ROUTING), all interrupts of the virtual
+//! machine must be updated all together. The [KvmIrqRouting](struct.KvmIrqRouting.html)
+//! structure is to maintain the global interrupt routing table.
+
+use std::collections::HashMap;
+use std::sync::{Arc, Mutex};
+
+use kvm_bindings::{kvm_irq_routing, kvm_irq_routing_entry};
+#[cfg(feature = "legacy_irq")]
+use kvm_bindings::{
+    KVM_IRQCHIP_IOAPIC, KVM_IRQCHIP_PIC_MASTER, KVM_IRQCHIP_PIC_SLAVE, KVM_IRQ_ROUTING_IRQCHIP,
+};
+use kvm_ioctls::VmFd;
+
+use super::*;
+
+/// Structure to manage interrupt sources for a virtual machine based on the Linux KVM framework.
+///
+/// The KVM framework provides methods to inject interrupts into the target virtual machines,
+/// which uses irqfd to notity the KVM kernel module for injecting interrupts. When the interrupt
+/// source, usually a virtual device backend in userspace, writes to the irqfd file descriptor,
+/// the KVM kernel module will inject a corresponding interrupt into the target VM according to
+/// the IRQ routing configuration.
+pub struct KvmIrqManager {
+    mgr: Mutex<KvmIrqManagerObj>,
+}
+
+impl KvmIrqManager {
+    /// Create a new interrupt manager based on the Linux KVM framework.
+    ///
+    /// # Arguments
+    /// * `vmfd`: The KVM VM file descriptor, which will be used to access the KVM subsystem.
+    pub fn new(vmfd: Arc<VmFd>) -> Self {
+        let vmfd2 = vmfd.clone();
+        KvmIrqManager {
+            mgr: Mutex::new(KvmIrqManagerObj {
+                vmfd,
+                groups: HashMap::new(),
+                routes: Arc::new(KvmIrqRouting::new(vmfd2)),
+            }),
+        }
+    }
+
+    /// Prepare the interrupt manager for generating interrupts into the target VM.
+    ///
+    /// On x86 platforms, this will set up IRQ routings for legacy IRQs.
+    pub fn initialize(&self) -> Result<()> {
+        // Safe to unwrap because there's no legal way to break the mutex.
+        let mgr = self.mgr.lock().unwrap();
+        mgr.initialize()
+    }
+}
+
+impl InterruptManager for KvmIrqManager {
+    fn create_group(
+        &self,
+        ty: InterruptSourceType,
+        base: InterruptIndex,
+        count: u32,
+    ) -> Result<Arc<dyn InterruptSourceGroup>> {
+        // Safe to unwrap because there's no legal way to break the mutex.
+        let mut mgr = self.mgr.lock().unwrap();
+        mgr.create_group(ty, base, count)
+    }
+
+    fn destroy_group(&self, group: Arc<dyn InterruptSourceGroup>) -> Result<()> {
+        // Safe to unwrap because there's no legal way to break the mutex.
+        let mut mgr = self.mgr.lock().unwrap();
+        mgr.destroy_group(group)
+    }
+}
+
+struct KvmIrqManagerObj {
+    vmfd: Arc<VmFd>,
+    routes: Arc<KvmIrqRouting>,
+    groups: HashMap<InterruptIndex, Arc<dyn InterruptSourceGroup>>,
+}
+
+impl KvmIrqManagerObj {
+    fn initialize(&self) -> Result<()> {
+        self.routes.initialize()?;
+        Ok(())
+    }
+
+    fn create_group(
+        &mut self,
+        ty: InterruptSourceType,
+        base: InterruptIndex,
+        count: u32,
+    ) -> Result<Arc<dyn InterruptSourceGroup>> {
+        let group = match ty {
+            #[cfg(feature = "legacy_irq")]
+            InterruptSourceType::LegacyIrq => {
+                LegacyIrq::new(base, count, self.vmfd.clone(), self.routes.clone())?
+            }
+            #[cfg(feature = "msi_irq")]
+            InterruptSourceType::MsiIrq => {
+                MsiIrq::new(base, count, self.vmfd.clone(), self.routes.clone())?
+            }
+        };
+
+        self.groups.insert(base, group.clone());
+
+        Ok(group)
+    }
+
+    fn destroy_group(&mut self, group: Arc<dyn InterruptSourceGroup>) -> Result<()> {
+        self.groups.remove(&group.get_base());
+        Ok(())
+    }
+}
+
+// Use (entry.type, entry.gsi) as the hash key because entry.gsi can't uniquely identify an
+// interrupt source on x86 platforms. The PIC and IOAPIC may share the same GSI on x86 platforms.
+fn hash_key(entry: &kvm_irq_routing_entry) -> u64 {
+    (u64::from(entry.type_) << 32) | u64::from(entry.gsi)
+}
+
+pub(super) struct KvmIrqRouting {
+    vm_fd: Arc<VmFd>,
+    routes: Mutex<HashMap<u64, kvm_irq_routing_entry>>,
+}
+
+impl KvmIrqRouting {
+    pub(super) fn new(vm_fd: Arc<VmFd>) -> Self {
+        KvmIrqRouting {
+            vm_fd,
+            routes: Mutex::new(HashMap::new()),
+        }
+    }
+
+    pub(super) fn initialize(&self) -> Result<()> {
+        // Safe to unwrap because there's no legal way to break the mutex.
+        #[allow(unused_mut)]
+        let mut routes = self.routes.lock().unwrap();
+
+        #[cfg(feature = "legacy_irq")]
+        self.initialize_legacy(&mut *routes)?;
+
+        self.commit(&*routes)
+    }
+
+    fn commit(&self, routes: &HashMap<u64, kvm_irq_routing_entry>) -> Result<()> {
+        // Allocate enough buffer memory.
+        let elem_sz = std::mem::size_of::<kvm_irq_routing>();
+        let total_sz = std::mem::size_of::<kvm_irq_routing_entry>() * routes.len() + elem_sz;
+        let elem_cnt = (total_sz + elem_sz - 1) / elem_sz;
+        let mut irq_routings = Vec::<kvm_irq_routing>::with_capacity(elem_cnt);
+        irq_routings.resize_with(elem_cnt, Default::default);
+
+        // Prepare the irq_routing header.
+        let mut irq_routing = &mut irq_routings[0];
+        irq_routing.nr = routes.len() as u32;
+        irq_routing.flags = 0;
+
+        // Safe because we have just allocated enough memory above.
+        let irq_routing_entries = unsafe { irq_routing.entries.as_mut_slice(routes.len()) };
+        for (idx, entry) in routes.values().enumerate() {
+            irq_routing_entries[idx] = *entry;
+        }
+
+        self.vm_fd.set_gsi_routing(irq_routing)?;
+
+        Ok(())
+    }
+
+    #[cfg(feature = "generic_msi")]
+    pub(super) fn add(&self, entries: &[kvm_irq_routing_entry]) -> Result<()> {
+        // Safe to unwrap because there's no legal way to break the mutex.
+        let mut routes = self.routes.lock().unwrap();
+        for entry in entries {
+            if entry.gsi >= MAX_IRQS {
+                return Err(std::io::Error::from_raw_os_error(libc::EINVAL));
+            } else if routes.contains_key(&hash_key(entry)) {
+                return Err(std::io::Error::from_raw_os_error(libc::EEXIST));
+            }
+        }
+
+        for entry in entries {
+            let _ = routes.insert(hash_key(entry), *entry);
+        }
+        self.commit(&*routes)
+    }
+
+    #[cfg(feature = "generic_msi")]
+    pub(super) fn remove(&self, entries: &[kvm_irq_routing_entry]) -> Result<()> {
+        // Safe to unwrap because there's no legal way to break the mutex.
+        let mut routes = self.routes.lock().unwrap();
+        for entry in entries {
+            let _ = routes.remove(&hash_key(entry));
+        }
+        self.commit(&routes)
+    }
+
+    #[cfg(feature = "generic_msi")]
+    pub(super) fn modify(&self, entry: &kvm_irq_routing_entry) -> Result<()> {
+        // Safe to unwrap because there's no legal way to break the mutex.
+        let mut routes = self.routes.lock().unwrap();
+        if !routes.contains_key(&hash_key(entry)) {
+            return Err(std::io::Error::from_raw_os_error(libc::ENOENT));
+        }
+
+        let _ = routes.insert(hash_key(entry), *entry);
+        self.commit(&routes)
+    }
+
+    #[cfg(feature = "legacy_irq")]
+    fn add_legacy_entry(
+        gsi: u32,
+        chip: u32,
+        pin: u32,
+        routes: &mut HashMap<u64, kvm_irq_routing_entry>,
+    ) -> Result<()> {
+        let mut entry = kvm_irq_routing_entry {
+            gsi,
+            type_: KVM_IRQ_ROUTING_IRQCHIP,
+            ..Default::default()
+        };
+        // Safe because we are initializing all fields of the `irqchip` struct.
+        unsafe {
+            entry.u.irqchip.irqchip = chip;
+            entry.u.irqchip.pin = pin;
+        }
+        routes.insert(hash_key(&entry), entry);
+
+        Ok(())
+    }
+
+    #[cfg(feature = "legacy_irq")]
+    /// Build routings for IRQs connected to the master PIC, the slave PIC or the first IOAPIC.
+    fn initialize_legacy(&self, routes: &mut HashMap<u64, kvm_irq_routing_entry>) -> Result<()> {
+        // Build routings for the master PIC
+        for i in 0..8 {
+            if i != 2 {
+                Self::add_legacy_entry(i, KVM_IRQCHIP_PIC_MASTER, i, routes)?;
+            }
+        }
+
+        // Build routings for the slave PIC
+        for i in 8..16 {
+            Self::add_legacy_entry(i, KVM_IRQCHIP_PIC_SLAVE, i - 8, routes)?;
+        }
+
+        // Build routings for the first IOAPIC
+        for i in 0..24 {
+            if i == 0 {
+                Self::add_legacy_entry(i, KVM_IRQCHIP_IOAPIC, 2, routes)?;
+            } else if i != 2 {
+                Self::add_legacy_entry(i, KVM_IRQCHIP_IOAPIC, i, routes)?;
+            };
+        }
+
+        Ok(())
+    }
+}

--- a/src/interrupt/kvm_irq/mod.rs
+++ b/src/interrupt/kvm_irq/mod.rs
@@ -131,7 +131,11 @@ impl KvmIrqManagerObj {
 // Use (entry.type, entry.gsi) as the hash key because entry.gsi can't uniquely identify an
 // interrupt source on x86 platforms. The PIC and IOAPIC may share the same GSI on x86 platforms.
 fn hash_key(entry: &kvm_irq_routing_entry) -> u64 {
-    (u64::from(entry.type_) << 32) | u64::from(entry.gsi)
+    let type1 = match entry.type_ {
+        KVM_IRQ_ROUTING_IRQCHIP => unsafe { entry.u.irqchip.irqchip },
+        _ => 0,
+    };
+    (u64::from(type1) << 48 | u64::from(entry.type_) << 32) | u64::from(entry.gsi)
 }
 
 pub(super) struct KvmIrqRouting {

--- a/src/interrupt/kvm_irq/msi_irq.rs
+++ b/src/interrupt/kvm_irq/msi_irq.rs
@@ -1,0 +1,147 @@
+// Copyright (C) 2019 Alibaba Cloud. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+//! Manage virtual device's PCI MSI/PCI MSIx interrupts based on Linux KVM framework.
+//!
+//! To optimize for performance by avoiding unnecessary locking and state checking, we assume that
+//! the caller will take the responsibility to maintain the interrupt states and only issue valid
+//! requests to this driver. If the caller doesn't obey the contract, only the current virtual
+//! machine will be affected, it shouldn't break the host or other virtual machines.
+
+use super::generic_msi::{create_msi_routing_entries, new_msi_routing_entry, MsiConfig};
+use super::*;
+use std::os::unix::io::AsRawFd;
+
+pub(super) struct MsiIrq {
+    base: InterruptIndex,
+    count: InterruptIndex,
+    vmfd: Arc<VmFd>,
+    irq_routing: Arc<KvmIrqRouting>,
+    msi_configs: Vec<MsiConfig>,
+}
+
+impl MsiIrq {
+    #[allow(clippy::new_ret_no_self)]
+    pub(super) fn new(
+        base: InterruptIndex,
+        count: InterruptIndex,
+        vmfd: Arc<VmFd>,
+        irq_routing: Arc<KvmIrqRouting>,
+    ) -> Result<Arc<dyn InterruptSourceGroup>> {
+        if count > MAX_MSI_IRQS_PER_DEVICE || base >= MAX_IRQS || base + count > MAX_IRQS {
+            return Err(std::io::Error::from_raw_os_error(libc::EINVAL));
+        }
+
+        let mut msi_configs = Vec::with_capacity(count as usize);
+        for _ in 0..count {
+            msi_configs.push(MsiConfig::new());
+        }
+
+        Ok(Arc::new(MsiIrq {
+            base,
+            count,
+            vmfd,
+            irq_routing,
+            msi_configs,
+        }))
+    }
+}
+
+impl InterruptSourceGroup for MsiIrq {
+    fn get_type(&self) -> InterruptSourceType {
+        InterruptSourceType::MsiIrq
+    }
+
+    fn len(&self) -> u32 {
+        self.count
+    }
+
+    fn get_base(&self) -> u32 {
+        self.base
+    }
+
+    fn get_irqfd(&self, index: InterruptIndex) -> Option<&EventFd> {
+        if index >= self.count {
+            None
+        } else {
+            let msi_config = &self.msi_configs[index as usize];
+            Some(&msi_config.irqfd)
+        }
+    }
+
+    fn enable(&self, configs: &[InterruptSourceConfig]) -> Result<()> {
+        if configs.len() != self.count as usize {
+            return Err(std::io::Error::from_raw_os_error(libc::EINVAL));
+        }
+
+        // First add IRQ routings for all the MSI interrupts.
+        let entries = create_msi_routing_entries(self.base, configs)?;
+        self.irq_routing.add(&entries)?;
+
+        // Then register irqfds to the KVM module.
+        for i in 0..self.count {
+            let irqfd = self.msi_configs[i as usize].irqfd.as_raw_fd();
+            self.vmfd.register_irqfd(irqfd, self.base + i)?;
+        }
+
+        Ok(())
+    }
+
+    fn disable(&self) -> Result<()> {
+        // First unregister all irqfds, so it won't trigger anymore.
+        for i in 0..self.count {
+            let irqfd = self.msi_configs[i as usize].irqfd.as_raw_fd();
+            self.vmfd.unregister_irqfd(irqfd, self.base + i)?;
+        }
+
+        // Then tear down the IRQ routings for all the MSI interrupts.
+        let mut entries = Vec::with_capacity(self.count as usize);
+        for i in 0..self.count {
+            // Safe to unwrap because there's no legal way to break the mutex.
+            let msicfg = self.msi_configs[i as usize].config.lock().unwrap();
+            let entry = new_msi_routing_entry(self.base + i, &*msicfg);
+            entries.push(entry);
+        }
+        self.irq_routing.remove(&entries)?;
+
+        Ok(())
+    }
+
+    fn modify(&self, index: InterruptIndex, config: &InterruptSourceConfig) -> Result<()> {
+        if index >= self.count {
+            return Err(std::io::Error::from_raw_os_error(libc::EINVAL));
+        }
+
+        if let InterruptSourceConfig::MsiIrq(ref cfg) = config {
+            // Safe to unwrap because there's no legal way to break the mutex.
+            let entry = {
+                let mut msicfg = self.msi_configs[index as usize].config.lock().unwrap();
+                msicfg.high_addr = cfg.high_addr;
+                msicfg.low_addr = cfg.low_addr;
+                msicfg.data = cfg.data;
+                new_msi_routing_entry(self.base + index, &*msicfg)
+            };
+            self.irq_routing.modify(&entry)
+        } else {
+            Err(std::io::Error::from_raw_os_error(libc::EINVAL))
+        }
+    }
+
+    fn trigger(&self, index: InterruptIndex, flags: u32) -> Result<()> {
+        // Assume that the caller will maintain the interrupt states and only call this function
+        // when suitable.
+        if index >= self.count || flags != 0 {
+            return Err(std::io::Error::from_raw_os_error(libc::EINVAL));
+        }
+        let msi_config = &self.msi_configs[index as usize];
+        msi_config.irqfd.write(1)
+    }
+
+    fn ack(&self, index: InterruptIndex, flags: u32) -> Result<()> {
+        // It's a noop to acknowledge an edge triggered MSI interrupts.
+        if index >= self.count || flags != 0 {
+            return Err(std::io::Error::from_raw_os_error(libc::EINVAL));
+        }
+        Ok(())
+    }
+}

--- a/src/interrupt/mod.rs
+++ b/src/interrupt/mod.rs
@@ -1,0 +1,214 @@
+// Copyright (C) 2019 Alibaba Cloud. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+//! Traits and Structs to manage interrupt sources for devices.
+//!
+//! In system programming, an interrupt is a signal to the processor emitted by hardware or
+//! software indicating an event that needs immediate attention. An interrupt alerts the processor
+//! to a high-priority condition requiring the interruption of the current code the processor is
+//! executing. The processor responds by suspending its current activities, saving its state, and
+//! executing a function called an interrupt handler (or an interrupt service routine, ISR) to deal
+//! with the event. This interruption is temporary, and, after the interrupt handler finishes,
+//! unless handling the interrupt has emitted a fatal error, the processor resumes normal
+//! activities.
+//!
+//! Hardware interrupts are used by devices to communicate that they require attention from the
+//! operating system, or a bare-metal program running on the CPU if there are no OSes. The act of
+//! initiating a hardware interrupt is referred to as an interrupt request (IRQ). Different devices
+//! are usually associated with different interrupts using a unique value associated with each
+//! interrupt. This makes it possible to know which hardware device caused which interrupts.
+//! These interrupt values are often called IRQ lines, or just interrupt lines.
+//!
+//! Nowadays, IRQ lines is not the only mechanism to delivery device interrupts to processors.
+//! MSI [(Message Signaled Interrupt)](https://en.wikipedia.org/wiki/Message_Signaled_Interrupts)
+//! is another commonly used alternative in-band method of signaling an interrupt, using special
+//! in-band messages to replace traditional out-of-band assertion of dedicated interrupt lines.
+//! While more complex to implement in a device, message signaled interrupts have some significant
+//! advantages over pin-based out-of-band interrupt signaling. Message signaled interrupts are
+//! supported in PCI bus since its version 2.2, and in later available PCI Express bus. Some non-PCI
+//! architectures also use message signaled interrupts.
+//!
+//! On the other hand, IRQ is a term commonly used by Operating Systems when dealing with hardware
+//! interrupts. The IRQ number managed by OSes is independent of the IRQ number managed by VMM.
+//! To make things easy, `Interrupt Source` is used instead of IRQ for pin-based interrupts and
+//! MSI interrupts.
+//!
+//! A device may support multiple types of interrupts, and each type of interrupt may support one
+//! or multiple interrupt sources. For example, a PCI device may support:
+//! * Legacy Irq: exactly one interrupt source.
+//! * PCI MSI Irq: 1,2,4,8,16,32 interrupt sources.
+//! * PCI MSIx Irq: 2^n(n=0-11) interrupt sources.
+//!
+//! A distinct Interrupt Source Identifier (ISID) will be assigned to each interrupt source.
+//! An ID allocator will be used to allocate and free Interrupt Source Identifiers for devices.
+//! To decouple the vm-device crate from the ID allocator, the vm-device crate doesn't take the
+//! responsibility to allocate/free Interrupt Source IDs but only makes use of assigned IDs.
+//!
+//! The overall flow to deal with interrupts is:
+//! * the VMM creates an interrupt manager
+//! * the VMM creates a device manager, passing on an reference to the interrupt manager
+//! * the device manager passes on an reference to the interrupt manager to all registered devices
+//! * guest kernel loads drivers for virtual devices
+//! * guest device driver determines the type and number of interrupts needed, and update the
+//!   device configuration
+//! * the virtual device backend requests the interrupt manager to create an interrupt group
+//!   according to guest configuration information
+
+use std::sync::Arc;
+use vmm_sys_util::eventfd::EventFd;
+
+/// Reuse std::io::Result to simplify inter operability among crates.
+pub type Result<T> = std::io::Result<T>;
+
+/// Data type to store an interrupt source identifier.
+pub type InterruptIndex = u32;
+
+/// Maximum number of global interrupt sources.
+pub const MAX_IRQS: InterruptIndex = 1024;
+
+#[cfg(feature = "generic_msi")]
+/// Maximum number of Message Signaled Interrupts per device.
+pub const MAX_MSI_IRQS_PER_DEVICE: InterruptIndex = 32;
+
+/// Type of interrupt source.
+pub enum InterruptSourceType {
+    #[cfg(feature = "legacy_irq")]
+    /// Legacy Pin-based Interrupt.
+    /// On x86 platforms, legacy interrupts are routed through 82599 PICs and/or IOAPICs.
+    LegacyIrq,
+    #[cfg(feature = "msi_irq")]
+    /// Message Signaled Interrupt (PCI MSI/PCI MSIx/Generic MSI).
+    /// Some non-PCI devices (like HPET on x86) make use of generic MSI in platform specific ways.
+    MsiIrq,
+}
+
+/// Configuration data for an interrupt source.
+pub enum InterruptSourceConfig {
+    #[cfg(feature = "legacy_irq")]
+    /// Configuration data for Legacy interrupts.
+    LegacyIrq(LegacyIrqSourceConfig),
+    #[cfg(feature = "generic_msi")]
+    /// Configuration data for GenericMsi, PciMsi, PciMsix interrupts.
+    MsiIrq(MsiIrqSourceConfig),
+}
+
+#[cfg(feature = "legacy_irq")]
+/// Configuration data for legacy interrupts.
+///
+/// On x86 platforms, legacy interrupts means those interrupts routed through PICs or IOAPICs.
+pub struct LegacyIrqSourceConfig {}
+
+#[cfg(feature = "generic_msi")]
+/// Configuration data for GenericMsi, PciMsi, PciMsix interrupts.
+#[derive(Default)]
+pub struct MsiIrqSourceConfig {
+    /// High address to delivery message signaled interrupt.
+    pub high_addr: u32,
+    /// Low address to delivery message signaled interrupt.
+    pub low_addr: u32,
+    /// Data to write to delivery message signaled interrupt.
+    pub data: u32,
+}
+
+/// Trait to manage interrupt sources for virtual device backends.
+///
+/// The InterruptManager implementations should protect itself from concurrent accesses internally,
+/// so it could be invoked from multi-threaded context.
+pub trait InterruptManager {
+    /// Create an [InterruptSourceGroup](trait.InterruptSourceGroup.html) object to manage
+    /// interrupt sources for a virtual device
+    ///
+    /// An [InterruptSourceGroup](trait.InterruptSourceGroup.html) object manages all interrupt
+    /// sources of the same type for a virtual device.
+    ///
+    /// # Arguments
+    /// * ty: type of interrupt source.
+    /// * base: base Interrupt Source ID to be managed by the group object.
+    /// * count: number of Interrupt Sources to be managed by the group object.
+    fn create_group(
+        &self,
+        ty: InterruptSourceType,
+        base: InterruptIndex,
+        count: InterruptIndex,
+    ) -> Result<Arc<dyn InterruptSourceGroup>>;
+
+    /// Destroy an [InterruptSourceGroup](trait.InterruptSourceGroup.html) object created by
+    /// [create_group()](trait.InterruptManager.html#tymethod.create_group).
+    ///
+    /// Assume the caller takes the responsibility to disable all interrupt sources of the group
+    /// before calling destroy_group(). This assumption helps to simplify InterruptSourceGroup
+    /// implementations.
+    fn destroy_group(&self, group: Arc<dyn InterruptSourceGroup>) -> Result<()>;
+}
+
+/// Trait to manage a group of interrupt sources for a device.
+///
+/// A device may support several types of interrupts, and each type of interrupt may contain one or
+/// multiple continuous interrupt sources. For example, a PCI device may concurrently support:
+/// * Legacy Irq: exactly one interrupt source.
+/// * PCI MSI Irq: 1,2,4,8,16,32 interrupt sources.
+/// * PCI MSIx Irq: 2^n(n=0-11) interrupt sources.
+///
+/// PCI MSI interrupts of a device may not be configured individually, and must configured as a
+/// whole block. So all interrupts of the same type of a device are abstracted as an
+/// [InterruptSourceGroup](trait.InterruptSourceGroup.html) object, instead of abstracting each
+/// interrupt source as a distinct InterruptSource.
+#[allow(clippy::len_without_is_empty)]
+pub trait InterruptSourceGroup: Send + Sync {
+    /// Get type of interrupt sources managed by the group.
+    fn get_type(&self) -> InterruptSourceType;
+
+    /// Get number of interrupt sources managed by the group.
+    fn len(&self) -> InterruptIndex;
+
+    /// Get base of the assigned Interrupt Source Identifiers.
+    fn get_base(&self) -> InterruptIndex;
+
+    /// Get the irqfd to inject interrupts into the guest by using Linux KVM module.
+    fn get_irqfd(&self, _index: InterruptIndex) -> Option<&EventFd> {
+        None
+    }
+
+    /// Get all irqfs of the interrupt group.
+    fn get_irqfds(&self) -> Option<Vec<&EventFd>> {
+        let mut irqfds = Vec::new();
+        for idx in 0..self.len() {
+            if let Some(fd) = self.get_irqfd(idx) {
+                irqfds.push(fd);
+            } else {
+                return None;
+            }
+        }
+        Some(irqfds)
+    }
+
+    /// Enable the interrupt sources in the group to generate interrupts.
+    fn enable(&self, configs: &[InterruptSourceConfig]) -> Result<()>;
+
+    /// Disable the interrupt sources in the group to generate interrupts.
+    fn disable(&self) -> Result<()>;
+
+    /// Change the configuration to generate interrupts.
+    ///
+    /// # Arguments
+    /// * index: sub-index into the group.
+    /// * config: configuration data for the interrupt source.
+    fn modify(&self, index: InterruptIndex, config: &InterruptSourceConfig) -> Result<()>;
+
+    /// Inject an interrupt into the guest.
+    ///
+    /// If the interrupt has an associated `interrupt_status` register, all bits set in `flag`
+    /// will be atomically ORed into the `interrupt_status` register.
+    fn trigger(&self, index: InterruptIndex, flags: u32) -> Result<()>;
+
+    /// Get interrupt flags.
+    fn get_flags(&self, _index: InterruptIndex) -> u32 {
+        0
+    }
+
+    /// Acknowledge that the guest has handled the interrupt.
+    ///
+    /// If the interrupt has an associated `interrupt_status` register, all bits set in `flag`
+    /// will get atomically cleared from the `interrupt_status` register.
+    fn ack(&self, index: InterruptIndex, flags: u32) -> Result<()>;
+}

--- a/src/interrupt/mod.rs
+++ b/src/interrupt/mod.rs
@@ -212,3 +212,8 @@ pub trait InterruptSourceGroup: Send + Sync {
     /// will get atomically cleared from the `interrupt_status` register.
     fn ack(&self, index: InterruptIndex, flags: u32) -> Result<()>;
 }
+
+#[cfg(feature = "kvm_irq")]
+mod kvm_irq;
+#[cfg(feature = "kvm_irq")]
+pub use kvm_irq::KvmIrqManager;

--- a/src/interrupt/mod.rs
+++ b/src/interrupt/mod.rs
@@ -214,6 +214,6 @@ pub trait InterruptSourceGroup: Send + Sync {
 }
 
 #[cfg(feature = "kvm_irq")]
-mod kvm_irq;
+pub mod kvm_irq;
 #[cfg(feature = "kvm_irq")]
 pub use kvm_irq::KvmIrqManager;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2,6 +2,8 @@
 
 //! TODO: add documentation
 
+pub mod interrupt;
+
 #[cfg(test)]
 mod tests {
     #[test]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,3 +1,7 @@
+#![deny(missing_docs)]
+
+//! TODO: add documentation
+
 #[cfg(test)]
 mod tests {
     #[test]


### PR DESCRIPTION
This PR adds two subsystem to the vm-device crate:
1) interrupt subsystem to manage interrupts for virtual devices.
2) the resource allocation interfaces between the vm-device crate and VMMs.