### PR TITLE
Add separate traits for Mmio and Pio devices and the manager functionality

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,6 +2,7 @@
 name = "vm-device"
 version = "0.1.0"
 authors = ["Samuel Ortiz <sameo@linux.intel.com>"]
+edition = "2018"
 repository = "https://github.com/rust-vmm/vm-device"
 license = "Apache-2.0"
 

--- a/coverage_config_x86_64.json
+++ b/coverage_config_x86_64.json
@@ -1,5 +1,5 @@
 {
-  "coverage_score": 80.2,
+  "coverage_score": 90.6,
   "exclude_path": "",
   "crate_features": ""
 }

--- a/src/bus/address.rs
+++ b/src/bus/address.rs
@@ -1,0 +1,177 @@
+// Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0 OR BSD-3-Clause
+
+use std::cmp::Ordering;
+use std::convert::TryFrom;
+use std::ops::{Add, Sub};
+
+/// This trait defines the operations we expect to apply to bus address values.
+pub trait BusAddress:
+    Add<<Self as BusAddress>::V, Output = Self>
+    + Copy
+    + Eq
+    + Ord
+    + Sub<Output = <Self as BusAddress>::V>
+{
+    /// Defines the underlying value type of the `BusAddress`.
+    type V: Add<Output = Self::V>
+        + Copy
+        + From<u8>
+        + PartialEq
+        + Ord
+        + Sub<Output = Self::V>
+        + TryFrom<usize>;
+
+    /// Return the inner value.
+    fn value(&self) -> Self::V;
+
+    /// Return the bus address computed by offsetting `self` by the specified value, if no
+    /// overflow occurs.
+    fn checked_add(&self, value: Self::V) -> Option<Self>;
+}
+
+/// Represents a MMIO address.
+#[derive(Clone, Copy, Debug)]
+pub struct MmioAddress(pub u64);
+
+/// This type defines the underlying value type for PIO addresses, which might be different
+/// for different platforms.
+pub type PioAddressValue = u16;
+
+/// Represents a PIO address.
+#[derive(Clone, Copy, Debug)]
+pub struct PioAddress(pub PioAddressValue);
+
+// Implementing `BusAddress` and its prerequisites for `MmioAddress`.
+
+impl PartialEq for MmioAddress {
+    fn eq(&self, other: &Self) -> bool {
+        self.0 == other.0
+    }
+}
+
+impl Eq for MmioAddress {}
+
+impl PartialOrd for MmioAddress {
+    fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
+        self.0.partial_cmp(&other.0)
+    }
+}
+
+impl Ord for MmioAddress {
+    fn cmp(&self, other: &Self) -> Ordering {
+        self.0.cmp(&other.0)
+    }
+}
+
+impl Add<u64> for MmioAddress {
+    type Output = Self;
+
+    fn add(self, rhs: u64) -> Self::Output {
+        MmioAddress(self.0 + rhs)
+    }
+}
+
+impl Sub for MmioAddress {
+    type Output = u64;
+
+    fn sub(self, rhs: Self) -> Self::Output {
+        self.0 - rhs.0
+    }
+}
+
+impl BusAddress for MmioAddress {
+    type V = u64;
+
+    fn value(&self) -> Self::V {
+        self.0
+    }
+
+    fn checked_add(&self, value: Self::V) -> Option<Self> {
+        self.0.checked_add(value).map(MmioAddress)
+    }
+}
+
+// Implementing `BusAddress` and its prerequisites for `PioAddress`.
+
+impl PartialEq for PioAddress {
+    fn eq(&self, other: &Self) -> bool {
+        self.0 == other.0
+    }
+}
+
+impl Eq for PioAddress {}
+
+impl PartialOrd for PioAddress {
+    fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
+        self.0.partial_cmp(&other.0)
+    }
+}
+
+impl Ord for PioAddress {
+    fn cmp(&self, other: &Self) -> Ordering {
+        self.0.cmp(&other.0)
+    }
+}
+
+impl Add<PioAddressValue> for PioAddress {
+    type Output = Self;
+
+    fn add(self, rhs: PioAddressValue) -> Self::Output {
+        PioAddress(self.0 + rhs)
+    }
+}
+
+impl Sub for PioAddress {
+    type Output = PioAddressValue;
+
+    fn sub(self, rhs: Self) -> Self::Output {
+        self.0 - rhs.0
+    }
+}
+
+impl BusAddress for PioAddress {
+    type V = PioAddressValue;
+
+    fn value(&self) -> Self::V {
+        self.0
+    }
+
+    fn checked_add(&self, value: Self::V) -> Option<Self> {
+        self.0.checked_add(value).map(PioAddress)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    use std::fmt::Debug;
+
+    // `addr_zero` should be an address equivalent to 0, while `max_value` should contain the
+    // maximum possible address value.
+    fn check_bus_address_ops<A>(addr_zero: A, max_value: A::V)
+    where
+        A: BusAddress + Debug,
+        A::V: Debug,
+    {
+        let value = A::V::from(5);
+        let addr = addr_zero + value;
+
+        assert_eq!(addr, addr);
+        assert!(addr_zero < addr);
+        assert_eq!(addr - addr_zero, value);
+
+        assert_eq!(addr.value(), value);
+        assert_eq!(addr_zero.checked_add(value).unwrap(), addr);
+
+        let addr_max = addr_zero.checked_add(max_value).unwrap();
+        assert!(addr_max.checked_add(A::V::from(1)).is_none());
+    }
+
+    #[test]
+    fn test_address_ops() {
+        check_bus_address_ops(MmioAddress(0), std::u64::MAX);
+        check_bus_address_ops(PioAddress(0), std::u16::MAX);
+    }
+}

--- a/src/bus/mod.rs
+++ b/src/bus/mod.rs
@@ -11,6 +11,7 @@ mod range;
 
 use std::collections::BTreeMap;
 use std::convert::TryFrom;
+use std::fmt::{Display, Formatter};
 use std::result::Result;
 
 use address::BusAddress;
@@ -30,6 +31,19 @@ pub enum Error {
     /// Invalid range provided (either zero-sized, or last address overflows).
     InvalidRange,
 }
+
+impl Display for Error {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Error::DeviceNotFound => write!(f, "device not found"),
+            Error::DeviceOverlap => write!(f, "range overlaps with existing device"),
+            Error::InvalidAccessLength(len) => write!(f, "invalid access length ({})", len),
+            Error::InvalidRange => write!(f, "invalid range provided"),
+        }
+    }
+}
+
+impl std::error::Error for Error {}
 
 /// A bus that's agnostic to the range address type and device type.
 pub struct Bus<A: BusAddress, D> {

--- a/src/bus/mod.rs
+++ b/src/bus/mod.rs
@@ -84,8 +84,8 @@ impl<A: BusAddress, D> Bus<A, D> {
         Ok(())
     }
 
-    /// Unregister the device associated with `addr`.
-    pub fn unregister(&mut self, addr: A) -> Option<(BusRange<A>, D)> {
+    /// Deregister the device associated with `addr`.
+    pub fn deregister(&mut self, addr: A) -> Option<(BusRange<A>, D)> {
         let range = self.device(addr).map(|(range, _)| *range)?;
         self.devices.remove(&range).map(|device| (range, device))
     }
@@ -214,20 +214,20 @@ mod test {
                 Err(Error::DeviceNotFound)
             );
 
-            // Validate registration, and that `unregister` works for all addresses within a range.
+            // Validate registration, and that `deregister` works for all addresses within a range.
             for offset in 0..range2.size() {
                 let device2 = device + 1;
                 assert!(bus.register(range2, device2).is_ok());
                 assert_eq!(bus.devices.len(), 2);
 
                 let addr = range2.base().checked_add(offset).unwrap();
-                let (r, d) = bus.unregister(addr).unwrap();
+                let (r, d) = bus.deregister(addr).unwrap();
                 assert_eq!(bus.devices.len(), 1);
                 assert_eq!(r, range2);
                 assert_eq!(d, device2);
 
-                // A second unregister should fail.
-                assert!(bus.unregister(addr).is_none());
+                // A second deregister should fail.
+                assert!(bus.deregister(addr).is_none());
                 assert_eq!(bus.devices.len(), 1);
             }
 

--- a/src/bus/mod.rs
+++ b/src/bus/mod.rs
@@ -1,0 +1,247 @@
+// Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0 OR BSD-3-Clause
+
+//! Provides abstractions for modelling a bus, which is seen here as a mapping between
+//! disjoint intervals (ranges) from an address space and objects (devices) associated with them.
+//! A single device can be registered with multiple ranges, but no two ranges can overlap,
+//! regardless with their device associations.
+
+mod address;
+mod range;
+
+use std::collections::BTreeMap;
+use std::convert::TryFrom;
+use std::result::Result;
+
+use address::BusAddress;
+
+pub use address::{MmioAddress, PioAddress, PioAddressValue};
+pub use range::{BusRange, MmioRange, PioRange};
+
+/// Errors encountered during bus operations.
+#[derive(Debug, PartialEq)]
+pub enum Error {
+    /// No device is associated with the specified address or range.
+    DeviceNotFound,
+    /// Specified range overlaps an already registered range.
+    DeviceOverlap,
+    /// Access with invalid length attempted.
+    InvalidAccessLength(usize),
+    /// Invalid range provided (either zero-sized, or last address overflows).
+    InvalidRange,
+}
+
+/// A bus that's agnostic to the range address type and device type.
+pub struct Bus<A: BusAddress, D> {
+    devices: BTreeMap<BusRange<A>, D>,
+}
+
+impl<A: BusAddress, D> Default for Bus<A, D> {
+    fn default() -> Self {
+        Bus {
+            devices: BTreeMap::new(),
+        }
+    }
+}
+
+impl<A: BusAddress, D> Bus<A, D> {
+    /// Create an empty bus.
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Return the registered range and device associated with `addr`.
+    pub fn device(&self, addr: A) -> Option<(&BusRange<A>, &D)> {
+        self.devices
+            .range(..=BusRange::unit(addr))
+            .nth_back(0)
+            .filter(|pair| pair.0.last() >= addr)
+    }
+
+    /// Return the registered range and a mutable reference to the device
+    /// associated with `addr`.
+    pub fn device_mut(&mut self, addr: A) -> Option<(&BusRange<A>, &mut D)> {
+        self.devices
+            .range_mut(..=BusRange::unit(addr))
+            .nth_back(0)
+            .filter(|pair| pair.0.last() >= addr)
+    }
+
+    /// Register a device with the provided range.
+    pub fn register(&mut self, range: BusRange<A>, device: D) -> Result<(), Error> {
+        for r in self.devices.keys() {
+            if range.overlaps(r) {
+                return Err(Error::DeviceOverlap);
+            }
+        }
+
+        if self.devices.contains_key(&range) {
+            return Err(Error::DeviceOverlap);
+        }
+
+        self.devices.insert(range, device);
+
+        Ok(())
+    }
+
+    /// Unregister the device associated with `addr`.
+    pub fn unregister(&mut self, addr: A) -> Option<(BusRange<A>, D)> {
+        let range = self.device(addr).map(|(range, _)| *range)?;
+        self.devices.remove(&range).map(|device| (range, device))
+    }
+
+    /// Verify whether an access starting at `addr` with length `len` fits within any of
+    /// the registered ranges. Return the range and a handle to the device when present.
+    pub fn check_access(&self, addr: A, len: usize) -> Result<(&BusRange<A>, &D), Error> {
+        let access_range = BusRange::new(
+            addr,
+            A::V::try_from(len).map_err(|_| Error::InvalidAccessLength(len))?,
+        )
+        .map_err(|_| Error::InvalidRange)?;
+        self.device(addr)
+            .filter(|(range, _)| range.last() >= access_range.last())
+            .ok_or(Error::DeviceNotFound)
+    }
+}
+
+pub type MmioBus<D> = Bus<MmioAddress, D>;
+pub type PioBus<D> = Bus<PioAddress, D>;
+
+/// Helper trait that can be implemented by types which hold one or more buses.
+pub trait BusManager<A: BusAddress> {
+    /// Type of the objects held by the bus.
+    type D;
+
+    /// Return a reference to the bus.
+    fn bus(&self) -> &Bus<A, Self::D>;
+
+    /// Return a mutable reference to the bus.
+    fn bus_mut(&mut self) -> &mut Bus<A, Self::D>;
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+
+    #[test]
+    fn test_bus() {
+        let base = MmioAddress(10);
+        let base_prev = MmioAddress(base.value().checked_sub(1).unwrap());
+        let len = 10;
+        let range = MmioRange::new(base, len).unwrap();
+        let range_next = range.last().checked_add(1).unwrap();
+
+        let mut bus = Bus::new();
+        // The bus is agnostic to actual device types, so let's just use a numeric type here.
+        let device = 1u8;
+
+        assert_eq!(bus.devices.len(), 0);
+
+        bus.register(range, device).unwrap();
+        assert_eq!(bus.devices.len(), 1);
+
+        assert!(bus.device(base_prev).is_none());
+        assert!(bus.device_mut(base_prev).is_none());
+        assert!(bus.device(range_next).is_none());
+        assert!(bus.device_mut(range_next).is_none());
+
+        for offset in 0..len {
+            let addr = base.checked_add(offset).unwrap();
+
+            {
+                let (r, d) = bus.device(addr).unwrap();
+                assert_eq!(range, *r);
+                assert_eq!(device, *d);
+            }
+
+            {
+                let (r, d) = bus.device_mut(addr).unwrap();
+                assert_eq!(range, *r);
+                assert_eq!(device, *d);
+            }
+
+            // Let's also check invocations of `Bus::check_access`.
+            for start_offset in 0..offset {
+                let start_addr = base.checked_add(start_offset).unwrap();
+
+                let (r, d) = bus
+                    .check_access(start_addr, usize::try_from(offset - start_offset).unwrap())
+                    .unwrap();
+                assert_eq!(range, *r);
+                assert_eq!(device, *d);
+            }
+        }
+
+        // We detect overlaps even if it's another range associated with the same device (we don't
+        // implicitly merge ranges). `check_access` fails if the specified range does not fully
+        // fit within a region associated with a particular device.
+
+        {
+            let range2 = MmioRange::new(MmioAddress(1), 10).unwrap();
+            assert_eq!(bus.register(range2, device), Err(Error::DeviceOverlap));
+            assert_eq!(
+                bus.check_access(range2.base(), usize::try_from(range2.size()).unwrap()),
+                Err(Error::DeviceNotFound)
+            );
+        }
+
+        {
+            let range2 = MmioRange::new(range.last(), 10).unwrap();
+            assert_eq!(bus.register(range2, device), Err(Error::DeviceOverlap));
+            assert_eq!(
+                bus.check_access(range2.base(), usize::try_from(range2.size()).unwrap()),
+                Err(Error::DeviceNotFound)
+            );
+        }
+
+        {
+            let range2 = MmioRange::new(MmioAddress(1), range.last().value() + 100).unwrap();
+            assert_eq!(bus.register(range2, device), Err(Error::DeviceOverlap));
+            assert_eq!(
+                bus.check_access(range2.base(), usize::try_from(range2.size()).unwrap()),
+                Err(Error::DeviceNotFound)
+            );
+        }
+
+        {
+            // For a completely empty range, `check_access` should still fail, but `insert`
+            // will succeed.
+
+            let range2 = MmioRange::new(range.last().checked_add(1).unwrap(), 5).unwrap();
+
+            assert_eq!(
+                bus.check_access(range2.base(), usize::try_from(range2.size()).unwrap()),
+                Err(Error::DeviceNotFound)
+            );
+
+            // Validate registration, and that `unregister` works for all addresses within a range.
+            for offset in 0..range2.size() {
+                let device2 = device + 1;
+                assert!(bus.register(range2, device2).is_ok());
+                assert_eq!(bus.devices.len(), 2);
+
+                let addr = range2.base().checked_add(offset).unwrap();
+                let (r, d) = bus.unregister(addr).unwrap();
+                assert_eq!(bus.devices.len(), 1);
+                assert_eq!(r, range2);
+                assert_eq!(d, device2);
+
+                // A second unregister should fail.
+                assert!(bus.unregister(addr).is_none());
+                assert_eq!(bus.devices.len(), 1);
+            }
+
+            // Register the previous `device` for `range2`.
+            assert!(bus.register(range2, device).is_ok());
+            assert_eq!(bus.devices.len(), 2);
+
+            // Even though the new range is associated with the same device, and right after the
+            // previous one, accesses across multiple ranges are not allowed for now.
+            // TODO: Do we want to support this in the future?
+            assert_eq!(
+                bus.check_access(range.base(), usize::try_from(range.size() + 1).unwrap()),
+                Err(Error::DeviceNotFound)
+            );
+        }
+    }
+}

--- a/src/bus/range.rs
+++ b/src/bus/range.rs
@@ -1,0 +1,177 @@
+// Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0 OR BSD-3-Clause
+
+use std::cmp::Ordering;
+
+use crate::bus::{BusAddress, Error, MmioAddress, PioAddress};
+
+/// An interval in the address space of a bus.
+#[derive(Copy, Clone, Debug)]
+pub struct BusRange<A: BusAddress> {
+    base: A,
+    size: A::V,
+}
+
+impl<A: BusAddress> BusRange<A> {
+    /// Create a new range while checking for overflow.
+    pub fn new(base: A, size: A::V) -> Result<Self, Error> {
+        // A zero-length range is not valid.
+        if size == 0.into() {
+            return Err(Error::InvalidRange);
+        }
+
+        // Subtracting one, because a range that ends at the very edge of the address space
+        // is still valid.
+        base.checked_add(size - 1.into())
+            .ok_or(Error::InvalidRange)?;
+
+        Ok(BusRange { base, size })
+    }
+
+    /// Create a new unit range (its size equals `1`).
+    pub fn unit(base: A) -> Self {
+        BusRange {
+            base,
+            size: 1.into(),
+        }
+    }
+
+    /// Return the base address of this range.
+    pub fn base(&self) -> A {
+        self.base
+    }
+
+    pub fn size(&self) -> A::V {
+        self.size
+    }
+
+    /// Return the last bus address that's still part of the range.
+    pub fn last(&self) -> A {
+        self.base + (self.size - 1.into())
+    }
+
+    /// Check whether `self` and `other` overlap as intervals.
+    pub fn overlaps(&self, other: &BusRange<A>) -> bool {
+        !(self.base > other.last() || self.last() < other.base)
+    }
+}
+
+// We need to implement the following traits so we can use `BusRange` values with `BTreeMap`s.
+// This usage scenario requires treating ranges as if they supported a total order, but that's
+// not really possible with intervals, so we write the implementations as if `BusRange`s were
+// solely determined by their base addresses, and apply extra checks in the `Bus` logic.
+
+impl<A: BusAddress> PartialEq for BusRange<A> {
+    fn eq(&self, other: &BusRange<A>) -> bool {
+        self.base == other.base
+    }
+}
+
+impl<A: BusAddress> Eq for BusRange<A> {}
+
+impl<A: BusAddress> PartialOrd for BusRange<A> {
+    fn partial_cmp(&self, other: &BusRange<A>) -> Option<Ordering> {
+        self.base.partial_cmp(&other.base)
+    }
+}
+
+impl<A: BusAddress> Ord for BusRange<A> {
+    fn cmp(&self, other: &BusRange<A>) -> Ordering {
+        self.base.cmp(&other.base)
+    }
+}
+
+// Helper type aliases.
+pub type MmioRange = BusRange<MmioAddress>;
+pub type PioRange = BusRange<PioAddress>;
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_bus_range() {
+        let base_zero = MmioAddress(0);
+        let value = 5;
+
+        assert_eq!(BusRange::new(base_zero, 0), Err(Error::InvalidRange));
+
+        assert!(BusRange::new(base_zero, std::u64::MAX).is_ok());
+        assert!(BusRange::new(MmioAddress(1), std::u64::MAX).is_ok());
+        assert_eq!(
+            BusRange::new(MmioAddress(2), std::u64::MAX),
+            Err(Error::InvalidRange)
+        );
+
+        {
+            let range = BusRange::new(base_zero, value).unwrap();
+            assert_eq!(range.base(), base_zero);
+            assert_eq!(range.size(), value);
+            assert_eq!(range.last(), MmioAddress(value - 1));
+            assert!(range.base() < range.last());
+        }
+
+        {
+            let range = BusRange::unit(base_zero);
+            assert_eq!(range.base(), base_zero);
+            assert_eq!(range.last(), range.base());
+        }
+
+        // Let's test `BusRange::overlaps`.
+        {
+            let range = BusRange::new(MmioAddress(10), 10).unwrap();
+
+            let overlaps = |base_value, len_value| {
+                range.overlaps(&BusRange::new(MmioAddress(base_value), len_value).unwrap())
+            };
+
+            assert!(!overlaps(0, 5));
+            assert!(!overlaps(0, 10));
+            assert!(!overlaps(5, 5));
+
+            assert!(overlaps(0, 11));
+            assert!(overlaps(5, 6));
+            assert!(overlaps(5, 10));
+            assert!(overlaps(11, 15));
+            assert!(overlaps(5, 35));
+            assert!(overlaps(19, 1));
+            assert!(overlaps(19, 10));
+
+            assert!(!overlaps(20, 1));
+            assert!(!overlaps(30, 10));
+        }
+
+        // Finally, let's test the `BusRange` trait implementations that we added.
+        {
+            let base = MmioAddress(10);
+            let len = 10;
+
+            let range = BusRange::new(base, len).unwrap();
+
+            assert_eq!(range, range);
+            assert_eq!(range.cmp(&range), range.partial_cmp(&range).unwrap());
+            assert_eq!(range.cmp(&range), Ordering::Equal);
+
+            {
+                let other = BusRange::new(base, len + 1).unwrap();
+
+                // Still equal becase we're only comparing `base` values as part
+                // of the `eq` implementation.
+                assert_eq!(range, other);
+
+                assert_eq!(range.cmp(&other), range.partial_cmp(&other).unwrap());
+                assert_eq!(range.cmp(&other), Ordering::Equal);
+            }
+
+            {
+                let other = BusRange::unit(base.checked_add(1).unwrap());
+
+                // Different due to different base addresses.
+                assert_ne!(range, other);
+
+                assert_eq!(range.cmp(&other), range.partial_cmp(&other).unwrap());
+                assert_eq!(range.cmp(&other), Ordering::Less);
+            }
+        }
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -5,6 +5,7 @@
 
 use std::cmp::{Ord, Ordering, PartialOrd};
 
+pub mod bus;
 pub mod device_manager;
 pub mod resources;
 


### PR DESCRIPTION
Related to #22

Hi everyone! This PR proposes a way of splitting the `DeviceIo` traits and manager logic into distinct `Pio` and `Mmio` parts. Besides the reasons stated in #22, having a cleaner and trait-enforced separation is also useful because we can leverage the implicit checks and validations enforced by the type system, (FWIW) we can express things like "this device over here expects an entity that's `PioManager + MmioManager` to register itself (but this other one only needs `MmioManager`)", and we can use features or other configuration options to disable either functionality when desirable.

The PR introduces some bus-related abstractions, but uses basic types such as `u64` and `u16` for the bus address values. I'll switch to newtypes (i.e. `Mmio(64)`) and use a wider/platform-dependent underlying type for `Pio` addresses in a follow up if the overall direction of the PR makes sense (and I'll also add more tests).

The `DeviceIo` trait was removed in favor of the `DevicePio` and `DeviceMmio` traits. The `IoManager` leverages the newly added `MmioManager` and `PioManager` traits, which can be used to implement the respective functionality for any type that contains a bus of the appropriate type.

Looking forward to any feedback!