### PR TITLE
Define types for address offsets

### DIFF
--- a/src/bus/address.rs
+++ b/src/bus/address.rs
@@ -30,17 +30,19 @@ pub trait BusAddress:
     fn checked_add(&self, value: Self::V) -> Option<Self>;
 }
 
+/// Represents a MMIO address offset.
+pub type MmioAddressOffset = u64;
+
 /// Represents a MMIO address.
 #[derive(Clone, Copy, Debug)]
-pub struct MmioAddress(pub u64);
+pub struct MmioAddress(pub MmioAddressOffset);
 
-/// This type defines the underlying value type for PIO addresses, which might be different
-/// for different platforms.
-pub type PioAddressValue = u16;
+/// Represents a PIO address offset.
+pub type PioAddressOffset = u16;
 
 /// Represents a PIO address.
 #[derive(Clone, Copy, Debug)]
-pub struct PioAddress(pub PioAddressValue);
+pub struct PioAddress(pub PioAddressOffset);
 
 // Implementing `BusAddress` and its prerequisites for `MmioAddress`.
 
@@ -64,16 +66,16 @@ impl Ord for MmioAddress {
     }
 }
 
-impl Add<u64> for MmioAddress {
+impl Add<MmioAddressOffset> for MmioAddress {
     type Output = Self;
 
-    fn add(self, rhs: u64) -> Self::Output {
+    fn add(self, rhs: MmioAddressOffset) -> Self::Output {
         MmioAddress(self.0 + rhs)
     }
 }
 
 impl Sub for MmioAddress {
-    type Output = u64;
+    type Output = MmioAddressOffset;
 
     fn sub(self, rhs: Self) -> Self::Output {
         self.0 - rhs.0
@@ -81,7 +83,7 @@ impl Sub for MmioAddress {
 }
 
 impl BusAddress for MmioAddress {
-    type V = u64;
+    type V = MmioAddressOffset;
 
     fn value(&self) -> Self::V {
         self.0
@@ -114,16 +116,16 @@ impl Ord for PioAddress {
     }
 }
 
-impl Add<PioAddressValue> for PioAddress {
+impl Add<PioAddressOffset> for PioAddress {
     type Output = Self;
 
-    fn add(self, rhs: PioAddressValue) -> Self::Output {
+    fn add(self, rhs: PioAddressOffset) -> Self::Output {
         PioAddress(self.0 + rhs)
     }
 }
 
 impl Sub for PioAddress {
-    type Output = PioAddressValue;
+    type Output = PioAddressOffset;
 
     fn sub(self, rhs: Self) -> Self::Output {
         self.0 - rhs.0
@@ -131,7 +133,7 @@ impl Sub for PioAddress {
 }
 
 impl BusAddress for PioAddress {
-    type V = PioAddressValue;
+    type V = PioAddressOffset;
 
     fn value(&self) -> Self::V {
         self.0

--- a/src/bus/mod.rs
+++ b/src/bus/mod.rs
@@ -16,7 +16,7 @@ use std::result::Result;
 
 use address::BusAddress;
 
-pub use address::{MmioAddress, PioAddress, PioAddressValue};
+pub use address::{MmioAddress, MmioAddressOffset, PioAddress, PioAddressOffset};
 pub use range::{BusRange, MmioRange, PioRange};
 
 /// Errors encountered during bus operations.

--- a/src/device_manager.rs
+++ b/src/device_manager.rs
@@ -310,7 +310,7 @@ mod tests {
     use std::error::Error;
     use std::sync::Mutex;
 
-    use bus::PioAddressValue;
+    use bus::{MmioAddressOffset, PioAddressOffset};
 
     const PIO_ADDRESS_SIZE: u16 = 4;
     const PIO_ADDRESS_BASE: u16 = 0x40;
@@ -332,7 +332,7 @@ mod tests {
     }
 
     impl DevicePio for DummyDevice {
-        fn pio_read(&self, _base: PioAddress, _offset: PioAddressValue, data: &mut [u8]) {
+        fn pio_read(&self, _base: PioAddress, _offset: PioAddressOffset, data: &mut [u8]) {
             if data.len() > 4 {
                 return;
             }
@@ -342,14 +342,14 @@ mod tests {
             }
         }
 
-        fn pio_write(&self, _base: PioAddress, _offset: PioAddressValue, data: &[u8]) {
+        fn pio_write(&self, _base: PioAddress, _offset: PioAddressOffset, data: &[u8]) {
             let mut config = self.config.lock().expect("failed to acquire lock");
             *config = u32::from(data[0]) & 0xff;
         }
     }
 
     impl DeviceMmio for DummyDevice {
-        fn mmio_read(&self, _base: MmioAddress, _offset: u64, data: &mut [u8]) {
+        fn mmio_read(&self, _base: MmioAddress, _offset: MmioAddressOffset, data: &mut [u8]) {
             if data.len() > 4 {
                 return;
             }
@@ -359,7 +359,7 @@ mod tests {
             }
         }
 
-        fn mmio_write(&self, _base: MmioAddress, _offset: u64, data: &[u8]) {
+        fn mmio_write(&self, _base: MmioAddress, _offset: MmioAddressOffset, data: &[u8]) {
             let mut config = self.config.lock().expect("failed to acquire lock");
             *config = u32::from(data[0]) & 0xff;
         }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -10,16 +10,16 @@ pub mod resources;
 use std::ops::Deref;
 use std::sync::{Arc, Mutex};
 
-use bus::{MmioAddress, PioAddress, PioAddressValue};
+use bus::{MmioAddress, MmioAddressOffset, PioAddress, PioAddressOffset};
 
 pub trait DevicePio {
-    fn pio_read(&self, base: PioAddress, offset: PioAddressValue, data: &mut [u8]);
-    fn pio_write(&self, base: PioAddress, offset: PioAddressValue, data: &[u8]);
+    fn pio_read(&self, base: PioAddress, offset: PioAddressOffset, data: &mut [u8]);
+    fn pio_write(&self, base: PioAddress, offset: PioAddressOffset, data: &[u8]);
 }
 
 pub trait DeviceMmio {
-    fn mmio_read(&self, base: MmioAddress, offset: u64, data: &mut [u8]);
-    fn mmio_write(&self, base: MmioAddress, offset: u64, data: &[u8]);
+    fn mmio_read(&self, base: MmioAddress, offset: MmioAddressOffset, data: &mut [u8]);
+    fn mmio_write(&self, base: MmioAddress, offset: MmioAddressOffset, data: &[u8]);
 }
 
 // TODO: turn into actual doc comments.
@@ -28,33 +28,33 @@ pub trait DeviceMmio {
 // mutability properties).
 
 pub trait MutDevicePio {
-    fn pio_read(&mut self, base: PioAddress, offset: PioAddressValue, data: &mut [u8]);
-    fn pio_write(&mut self, base: PioAddress, offset: PioAddressValue, data: &[u8]);
+    fn pio_read(&mut self, base: PioAddress, offset: PioAddressOffset, data: &mut [u8]);
+    fn pio_write(&mut self, base: PioAddress, offset: PioAddressOffset, data: &[u8]);
 }
 
 pub trait MutDeviceMmio {
-    fn mmio_read(&mut self, base: MmioAddress, offset: u64, data: &mut [u8]);
-    fn mmio_write(&mut self, base: MmioAddress, offset: u64, data: &[u8]);
+    fn mmio_read(&mut self, base: MmioAddress, offset: MmioAddressOffset, data: &mut [u8]);
+    fn mmio_write(&mut self, base: MmioAddress, offset: MmioAddressOffset, data: &[u8]);
 }
 
 // Blanket implementations for Arc<T>.
 
 impl<T: DeviceMmio + ?Sized> DeviceMmio for Arc<T> {
-    fn mmio_read(&self, base: MmioAddress, offset: u64, data: &mut [u8]) {
+    fn mmio_read(&self, base: MmioAddress, offset: MmioAddressOffset, data: &mut [u8]) {
         self.deref().mmio_read(base, offset, data);
     }
 
-    fn mmio_write(&self, base: MmioAddress, offset: u64, data: &[u8]) {
+    fn mmio_write(&self, base: MmioAddress, offset: MmioAddressOffset, data: &[u8]) {
         self.deref().mmio_write(base, offset, data);
     }
 }
 
 impl<T: DevicePio + ?Sized> DevicePio for Arc<T> {
-    fn pio_read(&self, base: PioAddress, offset: PioAddressValue, data: &mut [u8]) {
+    fn pio_read(&self, base: PioAddress, offset: PioAddressOffset, data: &mut [u8]) {
         self.deref().pio_read(base, offset, data);
     }
 
-    fn pio_write(&self, base: PioAddress, offset: PioAddressValue, data: &[u8]) {
+    fn pio_write(&self, base: PioAddress, offset: PioAddressOffset, data: &[u8]) {
         self.deref().pio_write(base, offset, data);
     }
 }
@@ -62,21 +62,21 @@ impl<T: DevicePio + ?Sized> DevicePio for Arc<T> {
 // Blanket implementations for Mutex<T>.
 
 impl<T: MutDeviceMmio + ?Sized> DeviceMmio for Mutex<T> {
-    fn mmio_read(&self, base: MmioAddress, offset: u64, data: &mut [u8]) {
+    fn mmio_read(&self, base: MmioAddress, offset: MmioAddressOffset, data: &mut [u8]) {
         self.lock().unwrap().mmio_read(base, offset, data)
     }
 
-    fn mmio_write(&self, base: MmioAddress, offset: u64, data: &[u8]) {
+    fn mmio_write(&self, base: MmioAddress, offset: MmioAddressOffset, data: &[u8]) {
         self.lock().unwrap().mmio_write(base, offset, data)
     }
 }
 
 impl<T: MutDevicePio + ?Sized> DevicePio for Mutex<T> {
-    fn pio_read(&self, base: PioAddress, offset: PioAddressValue, data: &mut [u8]) {
+    fn pio_read(&self, base: PioAddress, offset: PioAddressOffset, data: &mut [u8]) {
         self.lock().unwrap().pio_read(base, offset, data)
     }
 
-    fn pio_write(&self, base: PioAddress, offset: PioAddressValue, data: &[u8]) {
+    fn pio_write(&self, base: PioAddress, offset: PioAddressOffset, data: &[u8]) {
         self.lock().unwrap().pio_write(base, offset, data)
     }
 }


### PR DESCRIPTION
~This type alias is added for the symmetry with PioAddressValue.~

Add `MmioAddressOffset` and rename `PioAddressValue` to `PioAddressOffset` to make the naming more clear.

Closes https://github.com/rust-vmm/vm-device/issues/57

Signed-off-by: Sergii Glushchenko <gsserge@amazon.com>