### PR TITLE
Move PIO and MMIO methods to IoManager

### DIFF
--- a/src/bus/mod.rs
+++ b/src/bus/mod.rs
@@ -124,18 +124,6 @@ impl<A: BusAddress, D> Bus<A, D> {
 pub type MmioBus<D> = Bus<MmioAddress, D>;
 pub type PioBus<D> = Bus<PioAddress, D>;
 
-/// Helper trait that can be implemented by types which hold one or more buses.
-pub trait BusManager<A: BusAddress> {
-    /// Type of the objects held by the bus.
-    type D;
-
-    /// Return a reference to the bus.
-    fn bus(&self) -> &Bus<A, Self::D>;
-
-    /// Return a mutable reference to the bus.
-    fn bus_mut(&mut self) -> &mut Bus<A, Self::D>;
-}
-
 #[cfg(test)]
 mod test {
     use super::*;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -7,8 +7,7 @@ pub mod bus;
 pub mod device_manager;
 pub mod resources;
 
-use std::ops::Deref;
-use std::sync::{Arc, Mutex};
+use std::sync::Mutex;
 
 use bus::{MmioAddress, MmioAddressOffset, PioAddress, PioAddressOffset};
 
@@ -35,28 +34,6 @@ pub trait MutDevicePio {
 pub trait MutDeviceMmio {
     fn mmio_read(&mut self, base: MmioAddress, offset: MmioAddressOffset, data: &mut [u8]);
     fn mmio_write(&mut self, base: MmioAddress, offset: MmioAddressOffset, data: &[u8]);
-}
-
-// Blanket implementations for Arc<T>.
-
-impl<T: DeviceMmio + ?Sized> DeviceMmio for Arc<T> {
-    fn mmio_read(&self, base: MmioAddress, offset: MmioAddressOffset, data: &mut [u8]) {
-        self.deref().mmio_read(base, offset, data);
-    }
-
-    fn mmio_write(&self, base: MmioAddress, offset: MmioAddressOffset, data: &[u8]) {
-        self.deref().mmio_write(base, offset, data);
-    }
-}
-
-impl<T: DevicePio + ?Sized> DevicePio for Arc<T> {
-    fn pio_read(&self, base: PioAddress, offset: PioAddressOffset, data: &mut [u8]) {
-        self.deref().pio_read(base, offset, data);
-    }
-
-    fn pio_write(&self, base: PioAddress, offset: PioAddressOffset, data: &[u8]) {
-        self.deref().pio_write(base, offset, data);
-    }
 }
 
 // Blanket implementations for Mutex<T>.


### PR DESCRIPTION
This PR removes `PioManager`, `MmioManager` and `BusManager` and moves PIO and MMIO functions directly to `IoManager`. The blanket implementations for `Arc<T>` are also removed, because in `IoManager` we can call `.deref()` directly.

**Rationale**

https://github.com/rust-vmm/vm-device/pull/25 introduced a set of abstractions for clean separation between PIO and MMIO. However, I think that three of those abstractions, `PioManager`, `MmioManager` and `BusManager`, are making the implementation a bit too complicated. 

A sequence of blanket impls between `BusManager` <-> `MmioManager`/`PioManager` <-> `IoManager` is needed simply for the `IoManager` to provide a set of methods for operating devices and dispatching I/O. So effectively `PioManager` and `MmioManager` are **extension** traits. 

The problem is that there's no way for clients of this crate to **extend** it.  They can add another type for bus addresses, and another manager trait, say `AbcManager`, but the `IoManager` struct holds the actual supported busses (`pio_bus` and `mmio_bus`) and there's no way for the client code to add another one. So, if with all the complexity related to multiple traits and blanket impls clients still cannot extend the crate without making changes to the crate itself, it seems to me that the complexity is not justified.

**Impact for the existing code using `vm-device`**

Since `PioManager` and `MmioManager` do not exist anymore, their imports must be removed.

This PR is open as a draft and is meant as an RFC to discuss with the community.