### PR TITLE
Improve test coverage

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 /target
 **/*.rs.bk
 Cargo.lock
+kcov_output/

--- a/coverage_config_x86_64.json
+++ b/coverage_config_x86_64.json
@@ -1,5 +1,5 @@
 {
-  "coverage_score": 90.7,
+  "coverage_score": 92.7,
   "exclude_path": "",
   "crate_features": ""
 }

--- a/src/device_manager.rs
+++ b/src/device_manager.rs
@@ -377,12 +377,20 @@ mod tests {
             size: MMIO_ADDRESS_SIZE,
         };
         let irq = Resource::LegacyIrq(LEGACY_IRQ);
+        let pio = Resource::PioAddressRange {
+            base: PIO_ADDRESS_BASE,
+            size: PIO_ADDRESS_SIZE,
+        };
 
         resource.push(mmio);
         resource.push(irq);
+        resource.push(pio);
 
-        assert!(io_mgr.register_mmio_resources(dum, &resource).is_ok());
-        assert_eq!(io_mgr.deregister_resources(&resource), 1);
+        assert!(io_mgr
+            .register_mmio_resources(dum.clone(), &resource)
+            .is_ok());
+        assert!(io_mgr.register_pio_resources(dum, &resource).is_ok());
+        assert_eq!(io_mgr.deregister_resources(&resource), 2);
     }
 
     #[test]


### PR DESCRIPTION
Add new tests for device double registration, bus::check_access(),
and resources deregistration.

In addition, bus::register() does not require an additional check
that a new range is not present in the tree, because the range is
already checked for overlapping with any existing range.

Signed-off-by: Sergii Glushchenko <gsserge@amazon.com>