### PR TITLE
prepare for v0.1.0 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,9 @@
+# Changelog
+
+## v0.1.0
+
+This is the first `vm-device` release.
+The `vm-device` crate provides device traits defining read and write operations
+on specialized buses, a device manager for operating devices and dispatching
+I/O, and abstractions for defining resources and their constraints (e.g. a
+specific bus address range, IRQ number, etc.).

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,6 +2,8 @@
 name = "vm-device"
 version = "0.1.0"
 authors = ["Samuel Ortiz <sameo@linux.intel.com>", "Liu Jiang <gerry@linux.alibaba.com>", "rust-vmm AWS maintainers <rust-vmm-maintainers@amazon.com>"]
+description = "management for virtual devices and resources"
+keywords = ["bus", "manager", "virtualization"]
 edition = "2018"
 repository = "https://github.com/rust-vmm/vm-device"
 license = "Apache-2.0 OR BSD-3-Clause"


### PR DESCRIPTION
The description field is [a requirement](https://doc.rust-lang.org/cargo/reference/manifest.html#the-description-field) for publishing to crates.io.